### PR TITLE
#7: MeetingSheetVC 부모, MakeMeetingSheet & ModifyMeetingSheet 자식으로 상속 …

### DIFF
--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -57,6 +57,14 @@
 		5722462928C77D64009B7C78 /* SearchAddressResultBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722462828C77D64009B7C78 /* SearchAddressResultBottomSheet.swift */; };
 		5722462B28C77FA5009B7C78 /* SearchAddressResultTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722462A28C77FA5009B7C78 /* SearchAddressResultTableViewCell.swift */; };
 		5722462D28C77FE1009B7C78 /* SearchAddressResusltViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722462C28C77FE1009B7C78 /* SearchAddressResusltViewModel.swift */; };
+		5722462F28C8A0EE009B7C78 /* MeetingSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722462E28C8A0ED009B7C78 /* MeetingSheetViewController.swift */; };
+		5722463128C8A0FF009B7C78 /* ModifyMeetingSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722463028C8A0FF009B7C78 /* ModifyMeetingSheetViewController.swift */; };
+		5722463328C8A446009B7C78 /* MeetingSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722463228C8A446009B7C78 /* MeetingSheetViewModel.swift */; };
+		5722463528C8A455009B7C78 /* MakeMeetingSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722463428C8A455009B7C78 /* MakeMeetingSheetViewModel.swift */; };
+		5722463728C8A466009B7C78 /* ModifyMeetingSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722463628C8A466009B7C78 /* ModifyMeetingSheetViewModel.swift */; };
+		5722463928C8A479009B7C78 /* MeetingSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722463828C8A479009B7C78 /* MeetingSheetView.swift */; };
+		5722463B28C8A485009B7C78 /* MakeMeetingSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722463A28C8A485009B7C78 /* MakeMeetingSheetView.swift */; };
+		5722463D28C8A493009B7C78 /* ModifyMeetingSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722463C28C8A493009B7C78 /* ModifyMeetingSheetView.swift */; };
 		57468A6E289CFFB700056691 /* CategoryBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57468A6D289CFFB700056691 /* CategoryBottomSheet.swift */; };
 		57468A71289D044700056691 /* MySearchViewController+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57468A70289D044700056691 /* MySearchViewController+Layout.swift */; };
 		57468A74289D071100056691 /* UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57468A73289D071100056691 /* UIButton.swift */; };
@@ -206,6 +214,14 @@
 		5722462828C77D64009B7C78 /* SearchAddressResultBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAddressResultBottomSheet.swift; sourceTree = "<group>"; };
 		5722462A28C77FA5009B7C78 /* SearchAddressResultTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAddressResultTableViewCell.swift; sourceTree = "<group>"; };
 		5722462C28C77FE1009B7C78 /* SearchAddressResusltViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAddressResusltViewModel.swift; sourceTree = "<group>"; };
+		5722462E28C8A0ED009B7C78 /* MeetingSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSheetViewController.swift; sourceTree = "<group>"; };
+		5722463028C8A0FF009B7C78 /* ModifyMeetingSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyMeetingSheetViewController.swift; sourceTree = "<group>"; };
+		5722463228C8A446009B7C78 /* MeetingSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSheetViewModel.swift; sourceTree = "<group>"; };
+		5722463428C8A455009B7C78 /* MakeMeetingSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeMeetingSheetViewModel.swift; sourceTree = "<group>"; };
+		5722463628C8A466009B7C78 /* ModifyMeetingSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyMeetingSheetViewModel.swift; sourceTree = "<group>"; };
+		5722463828C8A479009B7C78 /* MeetingSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSheetView.swift; sourceTree = "<group>"; };
+		5722463A28C8A485009B7C78 /* MakeMeetingSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeMeetingSheetView.swift; sourceTree = "<group>"; };
+		5722463C28C8A493009B7C78 /* ModifyMeetingSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyMeetingSheetView.swift; sourceTree = "<group>"; };
 		57468A6D289CFFB700056691 /* CategoryBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryBottomSheet.swift; sourceTree = "<group>"; };
 		57468A70289D044700056691 /* MySearchViewController+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MySearchViewController+Layout.swift"; sourceTree = "<group>"; };
 		57468A73289D071100056691 /* UIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
@@ -442,12 +458,14 @@
 				571C0C6F28AB1B4D002293B6 /* ChattingListViewController+Layout.swift */,
 				578B7A9728AC6AF900E7B4F4 /* ChattingRoomViewController.swift */,
 				578B7A9928AC6CCF00E7B4F4 /* ChattingRoomViewController+Layout.swift */,
-				5722460D28C0745C009B7C78 /* MakeMeetingSheetViewController+Layout.swift */,
 				57C23CD128B231E5006E7915 /* ChattingSideSheetViewController.swift */,
 				5795770328BB1AB400237A12 /* MemberDeclarationBottomSheet.swift */,
-				5722460B28BF79D1009B7C78 /* MakeMeetingSheetViewController.swift */,
 				5722461728C6C822009B7C78 /* SearchAddressBottomSheet.swift */,
 				5722462828C77D64009B7C78 /* SearchAddressResultBottomSheet.swift */,
+				5722462E28C8A0ED009B7C78 /* MeetingSheetViewController.swift */,
+				5722460B28BF79D1009B7C78 /* MakeMeetingSheetViewController.swift */,
+				5722460D28C0745C009B7C78 /* MakeMeetingSheetViewController+Layout.swift */,
+				5722463028C8A0FF009B7C78 /* ModifyMeetingSheetViewController.swift */,
 			);
 			path = Chatting;
 			sourceTree = "<group>";
@@ -504,6 +522,9 @@
 				57C23CCF28B2073C006E7915 /* ChattingMatchBannerView.swift */,
 				5722461A28C6C89A009B7C78 /* SearchAddressView.swift */,
 				5722462628C778E0009B7C78 /* SearchAddressResultView.swift */,
+				5722463828C8A479009B7C78 /* MeetingSheetView.swift */,
+				5722463A28C8A485009B7C78 /* MakeMeetingSheetView.swift */,
+				5722463C28C8A493009B7C78 /* ModifyMeetingSheetView.swift */,
 			);
 			path = ChattingView;
 			sourceTree = "<group>";
@@ -680,6 +701,9 @@
 			children = (
 				5722461C28C6C8CA009B7C78 /* SearchAddressViewModel.swift */,
 				5722462C28C77FE1009B7C78 /* SearchAddressResusltViewModel.swift */,
+				5722463228C8A446009B7C78 /* MeetingSheetViewModel.swift */,
+				5722463428C8A455009B7C78 /* MakeMeetingSheetViewModel.swift */,
+				5722463628C8A466009B7C78 /* ModifyMeetingSheetViewModel.swift */,
 			);
 			path = ChattingViewModels;
 			sourceTree = "<group>";
@@ -1107,8 +1131,10 @@
 				576EA923282B7F840028046C /* FirstRegisterViewController.swift in Sources */,
 				5795770428BB1AB400237A12 /* MemberDeclarationBottomSheet.swift in Sources */,
 				5722460828BE0D0D009B7C78 /* RightChattingImageTableViewCell.swift in Sources */,
+				5722463328C8A446009B7C78 /* MeetingSheetViewModel.swift in Sources */,
 				57468A9B28A1098300056691 /* UITextField.swift in Sources */,
 				57DFC63B283636A7003AEB39 /* FirstRegisterTableViewCell.swift in Sources */,
+				5722463728C8A466009B7C78 /* ModifyMeetingSheetViewModel.swift in Sources */,
 				57468A71289D044700056691 /* MySearchViewController+Layout.swift in Sources */,
 				234E5DBC28C762810079640F /* TabBarViewController.swift in Sources */,
 				23CB3CF728C7D38F00C42858 /* MyZatchViewController.swift in Sources */,
@@ -1123,6 +1149,7 @@
 				5722461628C2F827009B7C78 /* AlertViewController.swift in Sources */,
 				57468A85289EB32000056691 /* FindSearchTagCollectionViewCell.swift in Sources */,
 				577A01B628A496D1004B2575 /* UITextView.swift in Sources */,
+				5722463128C8A0FF009B7C78 /* ModifyMeetingSheetViewController.swift in Sources */,
 				571C0C6C28AB151A002293B6 /* ChattingListViewController.swift in Sources */,
 				57468A9E28A1E5E300056691 /* ResultEmptyTableViewCell.swift in Sources */,
 				5722462D28C77FE1009B7C78 /* SearchAddressResusltViewModel.swift in Sources */,
@@ -1130,6 +1157,7 @@
 				57468A9628A000ED00056691 /* MyTagSearchResultCollectionViewCell.swift in Sources */,
 				5722460C28BF79D1009B7C78 /* MakeMeetingSheetViewController.swift in Sources */,
 				57B5D6D328346AB100EA1439 /* ProductInputTextFieldTabeViewCell.swift in Sources */,
+				5722462F28C8A0EE009B7C78 /* MeetingSheetViewController.swift in Sources */,
 				23A86A5B28C73D8600B073CB /* MainCollectionViewTableViewCell.swift in Sources */,
 				5767D78A286C0AF70075DB28 /* ZatchRoundCheck.swift in Sources */,
 				57067866281C167100F48342 /* UIFont.swift in Sources */,
@@ -1160,6 +1188,7 @@
 				57EBCE3728A7CC5F00212D20 /* PaddingLabel.swift in Sources */,
 				571C0C7B28AB584C002293B6 /* ChattingListTableViewCell+Layout.swift in Sources */,
 				57468A78289D2CD800056691 /* SearchTagCollectionViewCell.swift in Sources */,
+				5722463528C8A455009B7C78 /* MakeMeetingSheetViewModel.swift in Sources */,
 				57EBCE4A28AA17BE00212D20 /* DeleteImageDetailViewController.swift in Sources */,
 				571C0C7228AB1D56002293B6 /* BaseTabBarViewController.swift in Sources */,
 				57C23CD428B2698C006E7915 /* ChattingMemberTableViewCell.swift in Sources */,
@@ -1181,6 +1210,7 @@
 				571C0C7728AB5070002293B6 /* HiddenDeleteView.swift in Sources */,
 				57468A7B289D3C2300056691 /* CellCalledViewController.swift in Sources */,
 				5722461028C074AE009B7C78 /* TimePickerAlertViewController.swift in Sources */,
+				5722463B28C8A485009B7C78 /* MakeMeetingSheetView.swift in Sources */,
 				57468A74289D071100056691 /* UIButton.swift in Sources */,
 				571C0C7928AB5080002293B6 /* HiddenZatchInfoView.swift in Sources */,
 				57EBCE4628A923A900212D20 /* BaseTableViewCell.swift in Sources */,
@@ -1195,6 +1225,7 @@
 				57468A8E289FEF1800056691 /* WantZatchBottomSheet.swift in Sources */,
 				5752F1FA28200B8C004CA4A5 /* ResultTableViewCell.swift in Sources */,
 				57C585042821F2A70078FAFF /* ServiceType.swift in Sources */,
+				5722463D28C8A493009B7C78 /* ModifyMeetingSheetView.swift in Sources */,
 				23A86A5628C72C7700B073CB /* MainView.swift in Sources */,
 				5767D77B286883020075DB28 /* ProductInfoTableViewCell.swift in Sources */,
 				5722460428BCBD5C009B7C78 /* LeftChattingMessageTableViewCell.swift in Sources */,
@@ -1204,6 +1235,7 @@
 				57EBCE4828AA064C00212D20 /* RegisterImageDetailViewController.swift in Sources */,
 				57EBCE3E28A88EF200212D20 /* BasicAlertViewController.swift in Sources */,
 				57C23CCD28B1D93E006E7915 /* ChatEtcBtnView.swift in Sources */,
+				5722463928C8A479009B7C78 /* MeetingSheetView.swift in Sources */,
 				578B7A9828AC6AF900E7B4F4 /* ChattingRoomViewController.swift in Sources */,
 				23A86A5F28C7408C00B073CB /* MainCollectionViewCell.swift in Sources */,
 				5767D77D286944FB0075DB28 /* BottomFixView.swift in Sources */,

--- a/Zatch/domain/ViewControllers/Chatting/MeetingSheetViewController.swift
+++ b/Zatch/domain/ViewControllers/Chatting/MeetingSheetViewController.swift
@@ -1,0 +1,24 @@
+//
+//  MeetingSheetViewController.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/07.
+//
+
+import UIKit
+
+class MeetingSheetViewController: SheetViewController {
+
+    override func viewDidLoad() {
+        
+        super.viewDidLoad()
+        
+        sheetType = .MakeMeeting
+        super.titleLabel.removeFromSuperview()
+        
+//        setUpView()
+//        setUpConstraint()
+//        setUpViewProperties()
+    }
+
+}

--- a/Zatch/domain/ViewControllers/Chatting/ModifyMeetingSheetViewController.swift
+++ b/Zatch/domain/ViewControllers/Chatting/ModifyMeetingSheetViewController.swift
@@ -1,0 +1,12 @@
+//
+//  ModifyMeetingSheetViewController.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/07.
+//
+
+import UIKit
+
+class ModifyMeetingSheetViewController: MeetingSheetViewController {
+
+}

--- a/Zatch/domain/ViewModels/ChattingViewModels/MakeMeetingSheetViewModel.swift
+++ b/Zatch/domain/ViewModels/ChattingViewModels/MakeMeetingSheetViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  MakeMeetingSheetViewModel.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/07.
+//
+
+import UIKit
+
+class MakeMeetingSheetViewModel: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Zatch/domain/ViewModels/ChattingViewModels/MeetingSheetViewModel.swift
+++ b/Zatch/domain/ViewModels/ChattingViewModels/MeetingSheetViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  MeetingSheetViewModel.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/07.
+//
+
+import UIKit
+
+class MeetingSheetViewModel: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Zatch/domain/ViewModels/ChattingViewModels/ModifyMeetingSheetViewModel.swift
+++ b/Zatch/domain/ViewModels/ChattingViewModels/ModifyMeetingSheetViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  ModifyMeetingSheetViewModel.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/07.
+//
+
+import UIKit
+
+class ModifyMeetingSheetViewModel: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Zatch/domain/Views/ChattingView/MakeMeetingSheetView.swift
+++ b/Zatch/domain/Views/ChattingView/MakeMeetingSheetView.swift
@@ -1,0 +1,20 @@
+//
+//  MakeMeetingSheetView.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/07.
+//
+
+import UIKit
+
+class MakeMeetingSheetView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Zatch/domain/Views/ChattingView/MeetingSheetView.swift
+++ b/Zatch/domain/Views/ChattingView/MeetingSheetView.swift
@@ -1,0 +1,20 @@
+//
+//  MeetingSheetView.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/07.
+//
+
+import UIKit
+
+class MeetingSheetView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Zatch/domain/Views/ChattingView/ModifyMeetingSheetView.swift
+++ b/Zatch/domain/Views/ChattingView/ModifyMeetingSheetView.swift
@@ -1,0 +1,20 @@
+//
+//  ModifyMeetingSheetView.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/07.
+//
+
+import UIKit
+
+class ModifyMeetingSheetView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}


### PR DESCRIPTION
…관계 정의 후 파일 정리

## What is this PR? 🔍
#7: MeetingSheetVC 부모, MakeMeetingSheet & ModifyMeetingSheet 자식으로 상속 관계 정리 및 파일 구분

## Key Changes 🔑
1. MakeMeetingSheet과 ModifyMeetingSheet으로 생성, 수정 파일 구분
   - 부모로 MeetingSheetVC 설정 후 자식으로 MakeMeetingSheet, ModifyMeetingSheet 설정

## To Reviewers 📢
- 파일 추가했으니 머지와 풀을... 
