### PR TITLE
#43: 동네 설정 지도 관련 파일 추가 및 주소 정보 가공 통한 동네 정보 수집

### DIFF
--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -167,6 +167,8 @@
 		57A28CDD28CF05D800263079 /* DaumMap.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 57A28CBF28CF05D300263079 /* DaumMap.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57A28CDF28CF20AC00263079 /* LocationSearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A28CDE28CF20AC00263079 /* LocationSearchTextField.swift */; };
 		57A28CE228CF23FF00263079 /* MyTownTagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A28CE128CF23FF00263079 /* MyTownTagCollectionViewCell.swift */; };
+		57A28D0E28D03FAE00263079 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A28D0D28D03FAE00263079 /* String.swift */; };
+		57A28D1028D041F800263079 /* MapAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A28D0F28D041F800263079 /* MapAlertViewController.swift */; };
 		57B5D6D328346AB100EA1439 /* ProductInputTextFieldTabeViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5D6D228346AB100EA1439 /* ProductInputTextFieldTabeViewCell.swift */; };
 		57B5D6D6283475EA00EA1439 /* ImageAddTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5D6D5283475EA00EA1439 /* ImageAddTableViewCell.swift */; };
 		57C23CCD28B1D93E006E7915 /* ChatEtcBtnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C23CCC28B1D93E006E7915 /* ChatEtcBtnView.swift */; };
@@ -403,6 +405,8 @@
 		57A28CBF28CF05D300263079 /* DaumMap.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = DaumMap.framework; sourceTree = "<group>"; };
 		57A28CDE28CF20AC00263079 /* LocationSearchTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchTextField.swift; sourceTree = "<group>"; };
 		57A28CE128CF23FF00263079 /* MyTownTagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTownTagCollectionViewCell.swift; sourceTree = "<group>"; };
+		57A28D0D28D03FAE00263079 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		57A28D0F28D041F800263079 /* MapAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapAlertViewController.swift; sourceTree = "<group>"; };
 		57B5D6D228346AB100EA1439 /* ProductInputTextFieldTabeViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInputTextFieldTabeViewCell.swift; sourceTree = "<group>"; };
 		57B5D6D5283475EA00EA1439 /* ImageAddTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAddTableViewCell.swift; sourceTree = "<group>"; };
 		57C23CCC28B1D93E006E7915 /* ChatEtcBtnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEtcBtnView.swift; sourceTree = "<group>"; };
@@ -910,6 +914,7 @@
 				577A01B528A496D1004B2575 /* UITextView.swift */,
 				5722461E28C71665009B7C78 /* UIImageView.swift */,
 				57D6D79128CDB96900F805B7 /* UINavigationController.swift */,
+				57A28D0D28D03FAE00263079 /* String.swift */,
 			);
 			path = extenstion;
 			sourceTree = "<group>";
@@ -1120,6 +1125,7 @@
 				5722461328C230B3009B7C78 /* PickerAlertViewController.swift */,
 				57EBCE4128A8C67B00212D20 /* DatePickerAlertViewController.swift */,
 				5722460F28C074AE009B7C78 /* TimePickerAlertViewController.swift */,
+				57A28D0F28D041F800263079 /* MapAlertViewController.swift */,
 			);
 			path = Alert;
 			sourceTree = "<group>";
@@ -1536,8 +1542,10 @@
 				57468A74289D071100056691 /* UIButton.swift in Sources */,
 				571C0C7928AB5080002293B6 /* HiddenZatchInfoView.swift in Sources */,
 				57EBCE4628A923A900212D20 /* BaseTableViewCell.swift in Sources */,
+				57A28D0E28D03FAE00263079 /* String.swift in Sources */,
 				23CB3CFD28C7D8AF00C42858 /* MainViewModel.swift in Sources */,
 				57468A87289F575000056691 /* ResultSearchViewController+Layout.swift in Sources */,
+				57A28D1028D041F800263079 /* MapAlertViewController.swift in Sources */,
 				57468A81289E3FB600056691 /* BaseViewController.swift in Sources */,
 				57D6D7A628CDC34800F805B7 /* KakaoLocalDataManager.swift in Sources */,
 				57B5D6D6283475EA00EA1439 /* ImageAddTableViewCell.swift in Sources */,

--- a/Zatch/domain/ViewControllers/Town/MapTownViewController.swift
+++ b/Zatch/domain/ViewControllers/Town/MapTownViewController.swift
@@ -7,14 +7,20 @@
 
 import UIKit
 
-class MapTownViewController: UIViewController {
+class MapTownViewController: UIViewController{
     
     //MARK: - Properties
     var mapMarker = CustomMapMarker()
+    var geocoder: MTMapReverseGeoCoder!
     
-    let mainView = MapTownView()
+    //MARK: - UI
+    
+    let mainView = MapTownView().then{
+        $0.townSettingBtn.addTarget(self, action: #selector(willCertificationUserTown), for: .touchUpInside)
+    }
 
     override func viewDidLoad() {
+        
         super.viewDidLoad()
         
         self.navigationController?.isNavigationBarHidden = true
@@ -27,6 +33,10 @@ class MapTownViewController: UIViewController {
         
         mainView.mapView.delegate = self
     }
+    
+    @objc func willCertificationUserTown(){
+        print("certification start button click")
+    }
 }
 
 extension MapTownViewController: MTMapViewDelegate{
@@ -35,7 +45,8 @@ extension MapTownViewController: MTMapViewDelegate{
      //1. 지도 상에서 특정 위치 터치 -> singleTapOnMapPoint
      //2. 선택한 위치에 마커 표시 -> addPOIItem (1개만 표시되도록 설정)
      
-     3. 재치 시작하기 버튼 클릭시, 마커 위치 정보 통해 '동' 정보 추출하기
+     3. 카카오 로컬 api 통해 좌표로 주소 변환하기 or MTMapReverseGeoCoder 사용
+     4. 재치 시작하기 버튼 클릭시, 마커 위치 정보 통해 '동' 정보 추출하기
      
      추가. customDirectionImageAnchorPointOffset로 마커 중심 변경하기
      */
@@ -48,18 +59,17 @@ extension MapTownViewController: MTMapViewDelegate{
             
             self.showAnimationType = .springFromGround
             self.markerType = .customImage
-            self.customImage = UIImage(named: "map_marker") //map_marker
+            self.customImage = UIImage(named: "map_marker")
         }
         
     }
     
     func mapView(_ mapView: MTMapView!, singleTapOn mapPoint: MTMapPoint!) {
-        print("click event")
         
+        //map marker 지도에 한 개만 표시되도록 기존 마커 제거 후 새로 추가
         self.mapMarker.mapPoint = mapPoint
         mapView.remove(self.mapMarker)
         mapView.addPOIItems([self.mapMarker])
-        
     }
     
 }

--- a/Zatch/domain/ViewControllers/Town/MapTownViewController.swift
+++ b/Zatch/domain/ViewControllers/Town/MapTownViewController.swift
@@ -11,7 +11,8 @@ class MapTownViewController: UIViewController{
     
     //MARK: - Properties
     var mapMarker = CustomMapMarker()
-    var geocoder: MTMapReverseGeoCoder!
+    
+    var townInfo: String! //user의 동네 정보 담는 변수
     
     //MARK: - UI
     
@@ -35,7 +36,44 @@ class MapTownViewController: UIViewController{
     }
     
     @objc func willCertificationUserTown(){
-        print("certification start button click")
+
+        guard let mapPoint = self.mapMarker.mapPoint else{
+            print("map point value is nil")
+            return
+        }
+        
+        //좌표 -> 주소 변환 메서드
+        MTMapReverseGeoCoder.executeFindingAddress(for: mapPoint, openAPIKey: Const.KakaoAPI.KAKAO_APP_KEY, completionHandler: {isSuccess, address, error in
+            if(isSuccess){
+                if let address = address {
+                    self.addressProcessing(address: address)
+                }
+            }
+        })
+    }
+    
+    func addressProcessing(address: String){
+        
+        /* 동네 정보 전체 주소 케이스 5가지(동,면,읍,가)
+         3: 경기 성남시 분당구 정자동 112
+         2: 서울 성북구 안암동5가 1-2
+         2: 서울 동대문구 전농동 130-14
+         2: 경기 화성시 정남면 발산리 455-1
+         2: 충남 아산시 배방읍 회룡리 산 16
+         */
+        
+        print(address)
+        
+        let tokenString = address.components(separatedBy: " ")
+        let endCharacter = tokenString[2].returnEndCharacter()
+        
+        if(endCharacter == "동" || endCharacter == "면" || endCharacter == "읍" || endCharacter == "가"){
+            print("2번 인덱스")
+        }else if(tokenString[3].returnEndCharacter() == "동"){
+            print("3번 인덱스")
+        }
+        
+        
     }
 }
 
@@ -45,7 +83,7 @@ extension MapTownViewController: MTMapViewDelegate{
      //1. 지도 상에서 특정 위치 터치 -> singleTapOnMapPoint
      //2. 선택한 위치에 마커 표시 -> addPOIItem (1개만 표시되도록 설정)
      
-     3. 카카오 로컬 api 통해 좌표로 주소 변환하기 or MTMapReverseGeoCoder 사용
+     //3. 카카오 로컬 api 통해 좌표로 주소 변환하기 or MTMapReverseGeoCoder 사용
      4. 재치 시작하기 버튼 클릭시, 마커 위치 정보 통해 '동' 정보 추출하기
      
      추가. customDirectionImageAnchorPointOffset로 마커 중심 변경하기

--- a/Zatch/domain/ViewControllers/Town/MapTownViewController.swift
+++ b/Zatch/domain/ViewControllers/Town/MapTownViewController.swift
@@ -9,6 +9,9 @@ import UIKit
 
 class MapTownViewController: UIViewController {
     
+    //MARK: - Properties
+    var mapMarker = CustomMapMarker()
+    
     let mainView = MapTownView()
 
     override func viewDidLoad() {
@@ -27,5 +30,36 @@ class MapTownViewController: UIViewController {
 }
 
 extension MapTownViewController: MTMapViewDelegate{
+    
+    /*
+     //1. 지도 상에서 특정 위치 터치 -> singleTapOnMapPoint
+     //2. 선택한 위치에 마커 표시 -> addPOIItem (1개만 표시되도록 설정)
+     
+     3. 재치 시작하기 버튼 클릭시, 마커 위치 정보 통해 '동' 정보 추출하기
+     
+     추가. customDirectionImageAnchorPointOffset로 마커 중심 변경하기
+     */
+    
+    class CustomMapMarker: MTMapPOIItem{
+        
+        override init(){
+            
+            super.init()
+            
+            self.showAnimationType = .springFromGround
+            self.markerType = .customImage
+            self.customImage = UIImage(named: "map_marker") //map_marker
+        }
+        
+    }
+    
+    func mapView(_ mapView: MTMapView!, singleTapOn mapPoint: MTMapPoint!) {
+        print("click event")
+        
+        self.mapMarker.mapPoint = mapPoint
+        mapView.remove(self.mapMarker)
+        mapView.addPOIItems([self.mapMarker])
+        
+    }
     
 }

--- a/Zatch/domain/Views/TownView/MapTownView.swift
+++ b/Zatch/domain/Views/TownView/MapTownView.swift
@@ -26,7 +26,7 @@ class MapTownView: UIView {
         $0.baseMapType = .standard
     }
     
-    let townSettingBtn = Purple52Button(title: "재치 시작하기").then{
+    lazy var townSettingBtn = Purple52Button(title: "재치 시작하기").then{
         $0.layer.shadowColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.4).cgColor
         $0.layer.shadowOpacity = 1
         $0.layer.shadowRadius = 8

--- a/Zatch/global/Resource/Zatch-Bridging-Header.h
+++ b/Zatch/global/Resource/Zatch-Bridging-Header.h
@@ -11,5 +11,6 @@
 
 #import "UISheetPresentationControllerDetent+Private.h"
 #import <DaumMap/MTMapView.h>
+#import <DaumMap/MTMapReverseGeoCoder.h>
 
 #endif /* Zatch_Bridging_Header_h */

--- a/Zatch/global/Resource/extenstion/String.swift
+++ b/Zatch/global/Resource/extenstion/String.swift
@@ -1,0 +1,15 @@
+//
+//  UIString.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/13.
+//
+
+import Foundation
+
+extension String{
+    
+    func returnEndCharacter() -> Character{
+        return self[self.index(before: self.endIndex)]
+    }
+}

--- a/Zatch/global/Source/Alert/MapAlertViewController.swift
+++ b/Zatch/global/Source/Alert/MapAlertViewController.swift
@@ -1,0 +1,12 @@
+//
+//  MapAlertViewController.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/13.
+//
+
+import UIKit
+
+class MapAlertViewController: AlertViewController {
+    
+}


### PR DESCRIPTION
## What is this PR? 🔍
#43: 동네 설정 지도 관련 파일 추가 및 주소 정보 가공 통한 동네 정보 수집

## Key Changes 🔑
1. 카카오 지도 
   - 터치 이벤트시 커스텀 마커 추가
   - 추가한 마커로 동네 설정 시도시 좌표 -> 주소 데이터 반환해오며, 주소 데이터 가공 통해 동네 데이터 수집
2. string extension 파일 추가
   - extension 파일 추가
   - 문자열 마지막 인덱스의 값 반환하는 기능의 함수 추가
3. 새로운 alert 파일 추가
   - 동네 설정/약속잡기 지도에서 사용할 alert UI 구현 위한 파일 추가
## To Reviewers 📢
- 파일 추가되었습니다. 
