### PR TITLE
close #59: BaseVC 파일 상속 정리 및 적용

### DIFF
--- a/Pods/Pods.xcodeproj/xcuserdata/vertigo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Pods/Pods.xcodeproj/xcuserdata/vertigo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -8,66 +8,99 @@
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+		<key>Cosmos.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>1</integer>
 		</dict>
 		<key>KakaoSDKAuth.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>2</integer>
 		</dict>
 		<key>KakaoSDKCommon.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>3</integer>
 		</dict>
 		<key>KakaoSDKUser.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>4</integer>
 		</dict>
 		<key>Pods-Zatch-ZatchUITests.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>6</integer>
 		</dict>
 		<key>Pods-Zatch.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>5</integer>
 		</dict>
 		<key>Pods-ZatchTests.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>7</integer>
 		</dict>
 		<key>RxCocoa.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>8</integer>
 		</dict>
 		<key>RxRelay.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>9</integer>
 		</dict>
 		<key>RxSwift.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>10</integer>
 		</dict>
 		<key>SideMenu.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>11</integer>
 		</dict>
 		<key>SnapKit.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>12</integer>
 		</dict>
 		<key>Then.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
+			<key>orderHint</key>
+			<integer>13</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>

--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -103,6 +103,8 @@
 		576341A728D29CC70067D2C5 /* BlockUserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576341A628D29CC70067D2C5 /* BlockUserViewController.swift */; };
 		576341A928D29CE10067D2C5 /* BlockUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576341A828D29CE10067D2C5 /* BlockUserView.swift */; };
 		576341AB28D29D120067D2C5 /* BlockUserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576341AA28D29D120067D2C5 /* BlockUserTableViewCell.swift */; };
+		576341AD28D3EC3D0067D2C5 /* BaseLeftTitleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576341AC28D3EC3D0067D2C5 /* BaseLeftTitleViewController.swift */; };
+		576341AF28D3EC4D0067D2C5 /* BaseCenterTitleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576341AE28D3EC4D0067D2C5 /* BaseCenterTitleViewController.swift */; };
 		5767752C281CDA4B000BC7CD /* MySearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5767752B281CDA4B000BC7CD /* MySearchViewController.swift */; };
 		5767D7732868248E0075DB28 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5767D7722868248E0075DB28 /* DetailViewController.swift */; };
 		5767D77528682D120075DB28 /* ImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5767D77428682D120075DB28 /* ImageTableViewCell.swift */; };
@@ -328,6 +330,8 @@
 		576341A628D29CC70067D2C5 /* BlockUserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockUserViewController.swift; sourceTree = "<group>"; };
 		576341A828D29CE10067D2C5 /* BlockUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockUserView.swift; sourceTree = "<group>"; };
 		576341AA28D29D120067D2C5 /* BlockUserTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockUserTableViewCell.swift; sourceTree = "<group>"; };
+		576341AC28D3EC3D0067D2C5 /* BaseLeftTitleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseLeftTitleViewController.swift; sourceTree = "<group>"; };
+		576341AE28D3EC4D0067D2C5 /* BaseCenterTitleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCenterTitleViewController.swift; sourceTree = "<group>"; };
 		5767752B281CDA4B000BC7CD /* MySearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySearchViewController.swift; sourceTree = "<group>"; };
 		5767D7722868248E0075DB28 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		5767D77428682D120075DB28 /* ImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTableViewCell.swift; sourceTree = "<group>"; };
@@ -933,6 +937,8 @@
 				57C585032821F2A70078FAFF /* ServiceType.swift */,
 				571C0C7128AB1D56002293B6 /* BaseTabBarViewController.swift */,
 				57468A80289E3FB600056691 /* BaseViewController.swift */,
+				576341AC28D3EC3D0067D2C5 /* BaseLeftTitleViewController.swift */,
+				576341AE28D3EC4D0067D2C5 /* BaseCenterTitleViewController.swift */,
 				57468A8A289FEB2000056691 /* SheetViewController.swift */,
 				5722462428C772E9009B7C78 /* SheetNavigationViewController.swift */,
 				57EBCE4528A923A900212D20 /* BaseTableViewCell.swift */,
@@ -1611,8 +1617,10 @@
 				57D6D78D28CDB59100F805B7 /* MessageAlertViewController.swift in Sources */,
 				5722461028C074AE009B7C78 /* TimePickerAlertViewController.swift in Sources */,
 				57468A74289D071100056691 /* UIButton.swift in Sources */,
+				576341AD28D3EC3D0067D2C5 /* BaseLeftTitleViewController.swift in Sources */,
 				571C0C7928AB5080002293B6 /* HiddenZatchInfoView.swift in Sources */,
 				57EBCE4628A923A900212D20 /* BaseTableViewCell.swift in Sources */,
+				576341AF28D3EC4D0067D2C5 /* BaseCenterTitleViewController.swift in Sources */,
 				57A28D0E28D03FAE00263079 /* String.swift in Sources */,
 				23CB3CFD28C7D8AF00C42858 /* MainViewModel.swift in Sources */,
 				57468A87289F575000056691 /* ResultSearchViewController+Layout.swift in Sources */,

--- a/Zatch/domain/Cells/MypageCells/MyPage/BlockUserTableViewCell.swift
+++ b/Zatch/domain/Cells/MypageCells/MyPage/BlockUserTableViewCell.swift
@@ -8,13 +8,78 @@
 import UIKit
 
 class BlockUserTableViewCell: BaseTableViewCell {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    
+    static let cellIdentifier = "BlockUserTableViewCell"
+    
+    let userInfoStackView = UIStackView().then{
+        $0.spacing = 8
+        $0.axis = .horizontal
+        $0.alignment = .leading
     }
-    */
+    
+    let userImageView = UIImageView().then{
+        $0.backgroundColor = .black20
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = 32/2
+    }
+    
+    let userNameLabel = UILabel().then{
+        $0.text = "어리둥절 너구리"
+        $0.font = UIFont.pretendard(size: 14, family: .Medium)
+        $0.textColor = .black85
+    }
+    
+    lazy var unblockBtn = UIButton().then{
+        $0.setImage(UIImage(named: "exit"), for: .normal)
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setUpView()
+        setUpConstraint()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setUpView(){
+        
+        self.baseView.addSubview(userInfoStackView)
+        self.baseView.addSubview(unblockBtn)
+        
+        userInfoStackView.addArrangedSubview(userImageView)
+        userInfoStackView.addArrangedSubview(userNameLabel)
+        
+    }
+    
+    func setUpConstraint(){
+        
+        userInfoStackView.snp.makeConstraints{
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(24)
+            $0.top.equalToSuperview().offset(10)
+        }
+        
+        userImageView.snp.makeConstraints{
+            $0.top.bottom.leading.equalToSuperview()
+            $0.width.height.equalTo(32)
+        }
+        
+        unblockBtn.snp.makeConstraints{
+            $0.trailing.equalToSuperview().offset(-24)
+            $0.top.equalToSuperview().offset(14)
+            $0.centerY.equalToSuperview()
+            $0.width.equalTo(unblockBtn.snp.height)
+        }
+        
+        userNameLabel.snp.makeConstraints{
+            $0.centerY.equalToSuperview()
+        }
+    
+    }
+    
+    
 
 }

--- a/Zatch/domain/ViewControllers/Mypage/Mypage/BlockUserViewController.swift
+++ b/Zatch/domain/ViewControllers/Mypage/Mypage/BlockUserViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class BlockUserViewController: BaseViewController {
+class BlockUserViewController: BaseCenterTitleViewController {
     
     let mainView = BlockUserView()
 

--- a/Zatch/domain/ViewControllers/Mypage/Mypage/BlockUserViewController.swift
+++ b/Zatch/domain/ViewControllers/Mypage/Mypage/BlockUserViewController.swift
@@ -7,23 +7,53 @@
 
 import UIKit
 
-class BlockUserViewController: UIViewController {
+class BlockUserViewController: BaseViewController {
+    
+    let mainView = BlockUserView()
 
     override func viewDidLoad() {
+        
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        self.navigationTitle.text = "차단된 사용자"
+        
+        mainView.tableView.dataSource = self
+        mainView.tableView.delegate = self
+        
+        self.view.addSubview(mainView)
+        
+        mainView.snp.makeConstraints{
+            $0.top.equalToSuperview().offset(108)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
+        }
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    @objc func unblockBtnDidClicked(){
+        let alert = CancelAlertViewController(message: "해당 사용자를 차단 해제하시겠습니까?", btnTitle: "해제")
+        alert.modalPresentationStyle = .overFullScreen
+        alert.alertHandler = { isUnblock in
+            if(isUnblock){
+                print("ok")
+            }
+        }
+        self.present(alert, animated: false, completion: nil)
     }
-    */
+
+}
+
+extension BlockUserViewController: UITableViewDelegate, UITableViewDataSource{
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int{
+        return 5
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell{
+        
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: BlockUserTableViewCell.cellIdentifier, for: indexPath) as? BlockUserTableViewCell else { fatalError() }
+        
+        cell.unblockBtn.addTarget(self, action: #selector(unblockBtnDidClicked), for: .touchUpInside)
+        return cell
+    }
 
 }

--- a/Zatch/domain/ViewControllers/Register/CheckRegisterViewController.swift
+++ b/Zatch/domain/ViewControllers/Register/CheckRegisterViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class CheckRegisterViewController: BaseViewController {
+class CheckRegisterViewController: BaseLeftTitleViewController {
     
     //MARK: - Properties
     

--- a/Zatch/domain/ViewControllers/Register/FirstRegisterViewController.swift
+++ b/Zatch/domain/ViewControllers/Register/FirstRegisterViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class FirstRegisterViewController: BaseViewController {
+class FirstRegisterViewController: BaseLeftTitleViewController {
     
     //MARK: - Properties
     var isOpen = false

--- a/Zatch/domain/ViewControllers/Register/SecondRegisterViewController.swift
+++ b/Zatch/domain/ViewControllers/Register/SecondRegisterViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class SecondRegisterViewController: BaseViewController {
+class SecondRegisterViewController: BaseLeftTitleViewController {
     
     //MARK: - Properties
     

--- a/Zatch/domain/ViewControllers/Town/MapTownViewController.swift
+++ b/Zatch/domain/ViewControllers/Town/MapTownViewController.swift
@@ -59,6 +59,7 @@ class MapTownViewController: UIViewController{
     }
     
     @objc func backBtnDidClicked(){
+        self.navigationController?.popViewController(animated: true)
     }
     
     @objc func willCertificationUserTown(){

--- a/Zatch/domain/Views/MypageView/Mypage/BlockUserView.swift
+++ b/Zatch/domain/Views/MypageView/Mypage/BlockUserView.swift
@@ -16,8 +16,8 @@ class BlockUserView: UIView {
         super.init(frame: .zero)
         
         tableView = UITableView().then{
-            $0.separatorStyle = .none
             $0.showsVerticalScrollIndicator = false
+            $0.separatorStyle = .none
             
             $0.register(BlockUserTableViewCell.self, forCellReuseIdentifier: BlockUserTableViewCell.cellIdentifier)
         }

--- a/Zatch/domain/Views/MypageView/Mypage/BlockUserView.swift
+++ b/Zatch/domain/Views/MypageView/Mypage/BlockUserView.swift
@@ -8,13 +8,29 @@
 import UIKit
 
 class BlockUserView: UIView {
+    
+    var tableView: UITableView!
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    override init(frame: CGRect) {
+        
+        super.init(frame: .zero)
+        
+        tableView = UITableView().then{
+            $0.separatorStyle = .none
+            $0.showsVerticalScrollIndicator = false
+            
+            $0.register(BlockUserTableViewCell.self, forCellReuseIdentifier: BlockUserTableViewCell.cellIdentifier)
+        }
+        
+        self.addSubview(tableView)
+        
+        tableView.snp.makeConstraints{
+            $0.top.bottom.leading.trailing.equalToSuperview()
+        }
     }
-    */
-
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
 }

--- a/Zatch/domain/Views/SsooyaStoryboard.storyboard
+++ b/Zatch/domain/Views/SsooyaStoryboard.storyboard
@@ -8,10 +8,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Map Town View Controller-->
+        <!--Block User View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController modalPresentationStyle="fullScreen" id="Y6W-OH-hqX" customClass="MapTownViewController" customModule="Zatch" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="fullScreen" id="Y6W-OH-hqX" customClass="BlockUserViewController" customModule="Zatch" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Zatch/global/Source/BaseCenterTitleViewController.swift
+++ b/Zatch/global/Source/BaseCenterTitleViewController.swift
@@ -1,0 +1,22 @@
+//
+//  BaseCenterTitleViewController.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/16.
+//
+
+import UIKit
+
+class BaseCenterTitleViewController: BaseViewController{
+
+    override func viewDidLoad() {
+        
+        super.viewDidLoad()
+        
+        navigationView.addSubview(navigationTitle)
+        
+        navigationTitle.snp.makeConstraints{
+            $0.centerY.centerX.equalToSuperview()
+        }
+    }
+}

--- a/Zatch/global/Source/BaseLeftTitleViewController.swift
+++ b/Zatch/global/Source/BaseLeftTitleViewController.swift
@@ -1,0 +1,25 @@
+//
+//  BaseLeftTitleViewController.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/16.
+//
+
+import UIKit
+
+class BaseLeftTitleViewController: BaseViewController {
+
+    override func viewDidLoad() {
+        
+        super.viewDidLoad()
+        
+        navigationView.addSubview(navigationTitle)
+        
+        navigationTitle.snp.makeConstraints{
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(backBtn.snp.trailing).offset(4)
+        }
+    }
+    
+    
+}

--- a/Zatch/global/Source/BaseViewController.swift
+++ b/Zatch/global/Source/BaseViewController.swift
@@ -17,7 +17,7 @@ class BaseViewController: UIViewController {
         $0.addTarget(self, action: #selector(backBtnDidClicked), for: .touchUpInside)
     }
     
-    let navigationTitle = UILabel().then{
+    lazy var navigationTitle = UILabel().then{
         $0.font = UIFont.pretendard(size: 16, family: .Bold)
     }
 
@@ -28,13 +28,12 @@ class BaseViewController: UIViewController {
         self.navigationController?.isNavigationBarHidden = true
         self.view.backgroundColor = .white
         
-        //
+        //setUpView
         self.view.addSubview(navigationView)
         
         navigationView.addSubview(backBtn)
-        navigationView.addSubview(navigationTitle)
         
-        //
+        //setUpConstraint
         navigationView.snp.makeConstraints{ make in
             make.top.equalToSuperview().offset(44)
             make.leading.trailing.equalToSuperview()
@@ -45,11 +44,6 @@ class BaseViewController: UIViewController {
             make.width.height.equalTo(24)
             make.leading.equalToSuperview().offset(16)
             make.centerY.equalToSuperview()
-        }
-        
-        navigationTitle.snp.makeConstraints{ make in
-            make.centerY.equalToSuperview()
-            make.leading.equalTo(backBtn.snp.trailing).offset(4)
         }
     }
     


### PR DESCRIPTION
## What is this PR? 🔍
#59: BaseVC 파일 상속 정리 및 적용

## Key Changes 🔑
1. BaseVC 상속 정리
   - 네비게이션 타이틀 위치에 따른 상속 관계 정리가 필요했음
   - BaseVC에 타이틀 레이블 프로퍼티를 지연 연산(lazy 키워드) 사용
   - BaseVC 하위 클래스로 Left, Center 클래스 파일 생성

## To Reviewers 📢
- 2차인증 등 마이페이지에서는 BaseCenterTitleVC 적용시키면 됩니다~