### PR TITLE
close #55: MapAlert 상속 관계 정리 및 파일/코드 정리

### DIFF
--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		576341AB28D29D120067D2C5 /* BlockUserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576341AA28D29D120067D2C5 /* BlockUserTableViewCell.swift */; };
 		576341AD28D3EC3D0067D2C5 /* BaseLeftTitleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576341AC28D3EC3D0067D2C5 /* BaseLeftTitleViewController.swift */; };
 		576341AF28D3EC4D0067D2C5 /* BaseCenterTitleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576341AE28D3EC4D0067D2C5 /* BaseCenterTitleViewController.swift */; };
+		576341C428D40A200067D2C5 /* TownMapAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576341C328D40A200067D2C5 /* TownMapAlertViewController.swift */; };
+		576341C628D40A3A0067D2C5 /* MeetingMapAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576341C528D40A3A0067D2C5 /* MeetingMapAlertViewController.swift */; };
 		5767752C281CDA4B000BC7CD /* MySearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5767752B281CDA4B000BC7CD /* MySearchViewController.swift */; };
 		5767D7732868248E0075DB28 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5767D7722868248E0075DB28 /* DetailViewController.swift */; };
 		5767D77528682D120075DB28 /* ImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5767D77428682D120075DB28 /* ImageTableViewCell.swift */; };
@@ -332,6 +334,8 @@
 		576341AA28D29D120067D2C5 /* BlockUserTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockUserTableViewCell.swift; sourceTree = "<group>"; };
 		576341AC28D3EC3D0067D2C5 /* BaseLeftTitleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseLeftTitleViewController.swift; sourceTree = "<group>"; };
 		576341AE28D3EC4D0067D2C5 /* BaseCenterTitleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCenterTitleViewController.swift; sourceTree = "<group>"; };
+		576341C328D40A200067D2C5 /* TownMapAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TownMapAlertViewController.swift; sourceTree = "<group>"; };
+		576341C528D40A3A0067D2C5 /* MeetingMapAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingMapAlertViewController.swift; sourceTree = "<group>"; };
 		5767752B281CDA4B000BC7CD /* MySearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySearchViewController.swift; sourceTree = "<group>"; };
 		5767D7722868248E0075DB28 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		5767D77428682D120075DB28 /* ImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTableViewCell.swift; sourceTree = "<group>"; };
@@ -1197,6 +1201,8 @@
 				57EBCE4128A8C67B00212D20 /* DatePickerAlertViewController.swift */,
 				5722460F28C074AE009B7C78 /* TimePickerAlertViewController.swift */,
 				57A28D0F28D041F800263079 /* MapAlertViewController.swift */,
+				576341C328D40A200067D2C5 /* TownMapAlertViewController.swift */,
+				576341C528D40A3A0067D2C5 /* MeetingMapAlertViewController.swift */,
 			);
 			path = Alert;
 			sourceTree = "<group>";
@@ -1518,6 +1524,7 @@
 				57468A9B28A1098300056691 /* UITextField.swift in Sources */,
 				57A28B3D28CED93700263079 /* MapTownViewController.swift in Sources */,
 				57DFC63B283636A7003AEB39 /* FirstRegisterTableViewCell.swift in Sources */,
+				576341C428D40A200067D2C5 /* TownMapAlertViewController.swift in Sources */,
 				57468A71289D044700056691 /* MySearchViewController+Layout.swift in Sources */,
 				234E5DBC28C762810079640F /* TabBarViewController.swift in Sources */,
 				23CB3CF728C7D38F00C42858 /* MyZatchViewController.swift in Sources */,
@@ -1632,6 +1639,7 @@
 				577A01B828A49C97004B2575 /* CheckRegisterZatchInfoView.swift in Sources */,
 				57EBCE3B28A87BFD00212D20 /* ImageAddBtnCollectionViewCell.swift in Sources */,
 				57468A8B289FEB2000056691 /* SheetViewController.swift in Sources */,
+				576341C628D40A3A0067D2C5 /* MeetingMapAlertViewController.swift in Sources */,
 				576341A928D29CE10067D2C5 /* BlockUserView.swift in Sources */,
 				57D6D79528CDBC3A00F805B7 /* MeetingSheetView.swift in Sources */,
 				57D6D7A328CDC32200F805B7 /* KakaoLocalModel.swift in Sources */,

--- a/Zatch/domain/ViewControllers/Town/MapTownViewController.swift
+++ b/Zatch/domain/ViewControllers/Town/MapTownViewController.swift
@@ -53,7 +53,7 @@ class MapTownViewController: UIViewController{
         }
         
         mainView.mapView.delegate = self
-        mainView.mapView.currentLocationTrackingMode = .onWithoutHeading // 현 위치 트래킹 모드 on
+//        mainView.mapView.currentLocationTrackingMode = .onWithoutHeading // 현 위치 트래킹 모드 on
         mainView.mapView.setZoomLevel(0, animated: true)
         
     }
@@ -104,7 +104,7 @@ class MapTownViewController: UIViewController{
             
         }
         
-        let alert = MapAlertViewController()
+        let alert = TownMapAlertViewController()
         alert.townName = townInfo
         
         alert.modalPresentationStyle = .overFullScreen

--- a/Zatch/domain/Views/SsooyaStoryboard.storyboard
+++ b/Zatch/domain/Views/SsooyaStoryboard.storyboard
@@ -8,10 +8,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Block User View Controller-->
+        <!--Map Town View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController modalPresentationStyle="fullScreen" id="Y6W-OH-hqX" customClass="BlockUserViewController" customModule="Zatch" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="fullScreen" id="Y6W-OH-hqX" customClass="MapTownViewController" customModule="Zatch" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Zatch/global/Source/Alert/MapAlertViewController.swift
+++ b/Zatch/global/Source/Alert/MapAlertViewController.swift
@@ -9,13 +9,6 @@ import UIKit
 
 class MapAlertViewController: AlertViewController {
     
-    //MARK: - Properties
-    var townName: String! {
-        didSet{
-            self.messageLabel.text = "우리 동네가 ‘\(self.townName!)’이 맞나요?"
-        }
-    }
-    
     //MARK: - UI
     
     let characterImage = UIImageView().then{
@@ -26,7 +19,7 @@ class MapAlertViewController: AlertViewController {
         $0.font = UIFont.pretendard(size: 14, family: .Medium)
         $0.textColor = UIColor(red: 38/255, green: 38/255, blue: 38/255, alpha: 1)
         $0.textAlignment = .center
-        $0.numberOfLines = 1
+        $0.numberOfLines = 0
     }
     
     let cancelBtn = UIButton().then{
@@ -88,12 +81,6 @@ class MapAlertViewController: AlertViewController {
             $0.top.equalTo(messageLabel.snp.bottom).offset(8)
             $0.centerX.equalToSuperview()
         }
-    }
-    
-    override func okBtnDidClicked() {
-        
-        
-        super.okBtnDidClicked()
     }
     
     @objc func cancelBtnDidClicked(){

--- a/Zatch/global/Source/Alert/MeetingMapAlertViewController.swift
+++ b/Zatch/global/Source/Alert/MeetingMapAlertViewController.swift
@@ -1,0 +1,29 @@
+//
+//  MeetingMapAlertViewController.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/16.
+//
+
+import UIKit
+
+class MeetingMapAlertViewController: MapAlertViewController {
+    
+    //MARK: - Properties
+    var addressName: String! {
+        didSet{
+            self.messageLabel.text = "약속 장소가\n‘\(self.addressName!)’인가요?"
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+    override func okBtnDidClicked(){
+        
+        super.okBtnDidClicked()
+    }
+}

--- a/Zatch/global/Source/Alert/TownMapAlertViewController.swift
+++ b/Zatch/global/Source/Alert/TownMapAlertViewController.swift
@@ -1,0 +1,32 @@
+//
+//  TownMapAlertViewController.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/09/16.
+//
+
+import UIKit
+
+class TownMapAlertViewController: MapAlertViewController {
+
+    //MARK: - Properties
+    var townName: String! {
+        didSet{
+            self.messageLabel.text = "우리 동네가 ‘\(self.townName!)’ 인가요?"
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+    override func okBtnDidClicked(){
+        
+        super.okBtnDidClicked()
+    }
+
+    
+    
+}


### PR DESCRIPTION
## What is this PR? 🔍
close #55: MapAlert 상속 관계 정리 및 파일/코드 정리

## Key Changes 🔑
1. MapAlert 상속 관계 정리
   - MapAlert의 경우 동네 인증인 경우와 약속 잡기인 경우 UI는 동일하지만 message 형식이나 ok 버튼 클릭시 처리되는 과정에 차이가 있음
   - 자식 클래스로 구분 통해 UI는 추가로 건드리지 않고 각각의 기능을 수행할 수 있도록 함

## To Reviewers 📢
- Alert 관련 파일이 추가되었으니 풀 받고 사용해주세요. 
