### PR TITLE
Refactor: CategoryType 프로퍼티 및 메서드 -> 기존 ServiceType에 병합

### DIFF
--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -232,7 +232,7 @@
 		57B32C2E291F49DC0018C0CB /* SecondRegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B32C2D291F49DC0018C0CB /* SecondRegisterView.swift */; };
 		57B32C31291F56120018C0CB /* ZatchRegisterModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B32C30291F56120018C0CB /* ZatchRegisterModel.swift */; };
 		57B32C34291FB58F0018C0CB /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B32C33291FB58F0018C0CB /* Image.swift */; };
-		57B32C362920C5320018C0CB /* CategoryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B32C352920C5320018C0CB /* CategoryType.swift */; };
+		57B32C362920C5320018C0CB /* CategoryInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B32C352920C5320018C0CB /* CategoryInfo.swift */; };
 		57B5D6D328346AB100EA1439 /* ProductNameTabeViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5D6D228346AB100EA1439 /* ProductNameTabeViewCell.swift */; };
 		57B5D6D6283475EA00EA1439 /* ImageAddTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5D6D5283475EA00EA1439 /* ImageAddTableViewCell.swift */; };
 		57B9F70C28D94B7800ACEC94 /* Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B9F70B28D94B7800ACEC94 /* Delegate.swift */; };
@@ -532,7 +532,7 @@
 		57B32C2D291F49DC0018C0CB /* SecondRegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondRegisterView.swift; sourceTree = "<group>"; };
 		57B32C30291F56120018C0CB /* ZatchRegisterModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZatchRegisterModel.swift; sourceTree = "<group>"; };
 		57B32C33291FB58F0018C0CB /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
-		57B32C352920C5320018C0CB /* CategoryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryType.swift; sourceTree = "<group>"; };
+		57B32C352920C5320018C0CB /* CategoryInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryInfo.swift; sourceTree = "<group>"; };
 		57B5D6D228346AB100EA1439 /* ProductNameTabeViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductNameTabeViewCell.swift; sourceTree = "<group>"; };
 		57B5D6D5283475EA00EA1439 /* ImageAddTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAddTableViewCell.swift; sourceTree = "<group>"; };
 		57B9F70B28D94B7800ACEC94 /* Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Delegate.swift; sourceTree = "<group>"; };
@@ -1174,7 +1174,7 @@
 		571AD7112828D9C900390AAD /* Category */ = {
 			isa = PBXGroup;
 			children = (
-				57B32C352920C5320018C0CB /* CategoryType.swift */,
+				57B32C352920C5320018C0CB /* CategoryInfo.swift */,
 				571AD7122828D9EB00390AAD /* CategoryCollectionViewCell.swift */,
 				57468A6D289CFFB700056691 /* CategoryBottomSheet.swift */,
 			);
@@ -1958,7 +1958,7 @@
 				57D6D78F28CDB62000F805B7 /* InfoAlertViewController.swift in Sources */,
 				5724EC91291E122F00DC529B /* BaseView.swift in Sources */,
 				576B376628D8305200EF36E6 /* AlarmSettingTableViewCell.swift in Sources */,
-				57B32C362920C5320018C0CB /* CategoryType.swift in Sources */,
+				57B32C362920C5320018C0CB /* CategoryInfo.swift in Sources */,
 				57E75EBF28E3C32800AC24B2 /* DetailView.swift in Sources */,
 				232DD0A628ECDBC900BC6E91 /* ReviewViewController.swift in Sources */,
 				578B7A9C28AC892800E7B4F4 /* ChatInputView.swift in Sources */,

--- a/Zatch/domain/ViewControllers/Register/FirstRegisterViewController.swift
+++ b/Zatch/domain/ViewControllers/Register/FirstRegisterViewController.swift
@@ -162,7 +162,7 @@ extension FirstRegisterViewController: UITableViewDelegate, UITableViewDataSourc
         
         if(indexPath == [0,0]){
             
-            let vc = CategoryBottomSheet(type: .Zatch)
+            let vc = CategoryBottomSheet(service: .Zatch)
             
             vc.categorySelectHandler = { category in
                 guard let cell = tableView.cellForRow(at: indexPath) as? CategorySelectTableViewCell else{ return }

--- a/Zatch/domain/ViewControllers/Register/SecondRegisterViewController.swift
+++ b/Zatch/domain/ViewControllers/Register/SecondRegisterViewController.swift
@@ -143,7 +143,7 @@ extension SecondRegisterViewController: UITableViewDelegate, UITableViewDataSour
             dismissKeyboardView()
         }else{
             if(indexPath.row == 0){
-                let vc = CategoryBottomSheet(type: .Zatch)
+                let vc = CategoryBottomSheet(service: .Zatch)
                 vc.categorySelectHandler = { category in
                     
                     guard let cell = tableView.cellForRow(at: indexPath) as? CategorySelectTableViewCell else{ return }

--- a/Zatch/domain/ViewControllers/Search/ResultSearchViewController.swift
+++ b/Zatch/domain/ViewControllers/Search/ResultSearchViewController.swift
@@ -106,7 +106,7 @@ class ResultSearchViewController: BaseViewController, UIGestureRecognizerDelegat
     @objc
     func openCategoryBottomSheet(recognizer: UITapGestureRecognizer){
         
-        let vc = CategoryBottomSheet(type: .Zatch)
+        let vc = CategoryBottomSheet(service: .Zatch)
         
         vc.categorySelectHandler = { category in
             print(category)

--- a/Zatch/global/Source/Category/CategoryBottomSheet.swift
+++ b/Zatch/global/Source/Category/CategoryBottomSheet.swift
@@ -19,12 +19,12 @@ class CategoryBottomSheet: SheetViewController {
 
     var collectionView : UICollectionView!
     
-    var categoryType: CategoryType!
+    var service: ServiceType!
     
     //MARK: - LifeCycle
     
-    init(type: CategoryType){
-        self.categoryType = type
+    init(service: ServiceType){
+        self.service = service
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -84,7 +84,7 @@ class CategoryBottomSheet: SheetViewController {
 extension CategoryBottomSheet: UICollectionViewDelegate, UICollectionViewDataSource{
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return categoryType == .Zatch ? 15 : 16
+        return service == .Zatch ? 15 : 16
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -93,19 +93,16 @@ extension CategoryBottomSheet: UICollectionViewDelegate, UICollectionViewDataSou
             fatalError()
         }
         
-        let info = self.categoryType.getInfo(at: indexPath.row)
+        let category = self.service.getCategoryFromCategories(at: indexPath.row)
         
-        cell.categoryText.text = info.title
-        cell.categoryImage.image = info.image
+        cell.categoryText.text = category.title
+        cell.categoryImage.image = category.image
         
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
         self.dismiss(animated: true, completion: nil)
-        categorySelectHandler(self.categoryType.getInfo(at: indexPath.row).title)
+        categorySelectHandler(self.service.getCategoryFromCategories(at: indexPath.row).title)
     }
-    
-    
 }

--- a/Zatch/global/Source/Category/CategoryInfo.swift
+++ b/Zatch/global/Source/Category/CategoryInfo.swift
@@ -7,19 +7,14 @@
 
 import Foundation
 
-enum CategoryType{
-    case Zatch
-    case Gatch
-}
-
 struct CategoryInfo{
     let title: String
     let image: UIImage
 }
 
-extension CategoryType{
+extension ServiceType{
     
-    var categoryInfoList: [CategoryInfo]{
+    var categories: [CategoryInfo]{
         switch self{
         case .Zatch:    return [CategoryInfo(title: "음식", image: Image.category0)] + defaultCategories
         case .Gatch:    return [CategoryInfo(title: "음식|조리", image: Image.category0),
@@ -27,8 +22,8 @@ extension CategoryType{
         }
     }
     
-    func getInfo(at: Int) -> CategoryInfo{
-        return self.categoryInfoList[at]
+    func getCategoryFromCategories(at: Int) -> CategoryInfo{
+        return self.categories[at]
     }
 }
 


### PR DESCRIPTION
## What is this PR? 🔍
CategoryType 프로퍼티 및 메서드 -> 기존 ServiceType에 병합

## Key Changes 🔑
1. CategoryType 프로퍼티 및 메서드 ServiceType extension에 추가
   - 재치, 가치 서비스 구분 위한 ServiceType 열거형 존재
   - Category에서도 굳이 또 Type 지정하는 열거형 존재할 필요 없으며,  extension에 기능 구현했기 때문에 병합에 큰 무리X(재사용 가능)
   - 카테고리 정보 반환 프로퍼티 및 메서드 extension에 있었기 때문에, 동일하게 ServiceType의 extension으로 사용함

## To Reviewers 📢
- 프로젝트 파일 변경 및 공통 소스 리팩토링 진행했으므로 풀 받고 사용해주세요~
