### PR TITLE
#136: BottomSheetInfo 파일 분리

### DIFF
--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		57B32C31291F56120018C0CB /* ZatchRegisterModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B32C30291F56120018C0CB /* ZatchRegisterModel.swift */; };
 		57B32C34291FB58F0018C0CB /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B32C33291FB58F0018C0CB /* Image.swift */; };
 		57B32C362920C5320018C0CB /* CategoryInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B32C352920C5320018C0CB /* CategoryInfo.swift */; };
+		57B32C3829220EA10018C0CB /* BottomSheetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B32C3729220EA10018C0CB /* BottomSheetInfo.swift */; };
 		57B5D6D328346AB100EA1439 /* ProductNameTabeViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5D6D228346AB100EA1439 /* ProductNameTabeViewCell.swift */; };
 		57B5D6D6283475EA00EA1439 /* ImageAddTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5D6D5283475EA00EA1439 /* ImageAddTableViewCell.swift */; };
 		57B9F70C28D94B7800ACEC94 /* Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B9F70B28D94B7800ACEC94 /* Delegate.swift */; };
@@ -533,6 +534,7 @@
 		57B32C30291F56120018C0CB /* ZatchRegisterModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZatchRegisterModel.swift; sourceTree = "<group>"; };
 		57B32C33291FB58F0018C0CB /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		57B32C352920C5320018C0CB /* CategoryInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryInfo.swift; sourceTree = "<group>"; };
+		57B32C3729220EA10018C0CB /* BottomSheetInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetInfo.swift; sourceTree = "<group>"; };
 		57B5D6D228346AB100EA1439 /* ProductNameTabeViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductNameTabeViewCell.swift; sourceTree = "<group>"; };
 		57B5D6D5283475EA00EA1439 /* ImageAddTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAddTableViewCell.swift; sourceTree = "<group>"; };
 		57B9F70B28D94B7800ACEC94 /* Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Delegate.swift; sourceTree = "<group>"; };
@@ -1540,6 +1542,7 @@
 		57B32C28291E8FF60018C0CB /* Sheet */ = {
 			isa = PBXGroup;
 			children = (
+				57B32C3729220EA10018C0CB /* BottomSheetInfo.swift */,
 				57468A8A289FEB2000056691 /* SheetViewController.swift */,
 				5722462428C772E9009B7C78 /* SheetNavigationViewController.swift */,
 			);
@@ -2127,6 +2130,7 @@
 				576EA927282B7FD60028046C /* CheckRegisterViewController.swift in Sources */,
 				5767D77F28695BD60075DB28 /* MoreTextTableViewCell.swift in Sources */,
 				57EBCE4828AA064C00212D20 /* RegisterImageDetailViewController.swift in Sources */,
+				57B32C3829220EA10018C0CB /* BottomSheetInfo.swift in Sources */,
 				57EBCE3E28A88EF200212D20 /* BasicAlertViewController.swift in Sources */,
 				57B32C31291F56120018C0CB /* ZatchRegisterModel.swift in Sources */,
 				57C23CCD28B1D93E006E7915 /* ChatEtcBtnView.swift in Sources */,

--- a/Zatch/global/Source/Sheet/BottomSheetInfo.swift
+++ b/Zatch/global/Source/Sheet/BottomSheetInfo.swift
@@ -1,0 +1,52 @@
+//
+//  SheetInfo.swift
+//  Zatch
+//
+//  Created by 박지윤 on 2022/11/14.
+//
+
+import Foundation
+
+enum BottomSheetType{
+    case SearchMyTag
+    case SearchWantTag
+    case Category
+    case TownArea
+    case Declaration
+    case MakeMeeting
+    case LocationChange
+}
+
+struct BottomSheetInfo{
+    let title: String
+    let sheetHeight: CGFloat
+    let grabberVisibility: Bool = false
+}
+
+extension BottomSheetType{
+    
+    var info: BottomSheetInfo{
+        switch self{
+        case .SearchMyTag:      return BottomSheetInfo(title: "내가 등록한 재치", sheetHeight: 219)
+        case .SearchWantTag:    return BottomSheetInfo(title: "내가 찾는 재치", sheetHeight: 219)
+        case .Category:         return BottomSheetInfo(title: "카테고리", sheetHeight: 524)
+        case .TownArea:         return BottomSheetInfo(title: "동네 범위 설정", sheetHeight: 442)
+        case .Declaration:      return BottomSheetInfo(title: "", sheetHeight: 128)
+        case .MakeMeeting:      return BottomSheetInfo(title: "주소검색", sheetHeight: 324)
+        case .LocationChange:   return BottomSheetInfo(title: "내 동네 변경하기", sheetHeight: 216)
+        }
+    }
+    
+    var sheetHeight: CGFloat{
+        return self.info.sheetHeight
+    }
+    
+    var title: String?{
+        return self.info.title
+    }
+    
+    var grabberVisibility: Bool{
+        return self.info.grabberVisibility
+    }
+    
+}

--- a/Zatch/global/Source/Sheet/SheetViewController.swift
+++ b/Zatch/global/Source/Sheet/SheetViewController.swift
@@ -7,22 +7,6 @@
 
 import UIKit
 
-enum BottomSheetType{
-    case SearchMyTag
-    case SearchWantTag
-    case Category
-    case TownArea
-    case Declaration
-    case MakeMeeting
-    case LocationChange
-}
-
-struct BottomSheetInfo{
-    let title: String
-    let sheetHeight: CGFloat
-    let grabberVisibility: Bool = false
-}
-
 class SheetViewController: UIViewController, UIViewControllerTransitioningDelegate {
     
     //MARK: - Properties
@@ -102,31 +86,3 @@ class SheetViewController: UIViewController, UIViewControllerTransitioningDelega
      super.layout()
  }
  */
-
-extension BottomSheetType{
-    
-    var info: BottomSheetInfo{
-        switch self{
-        case .SearchMyTag:      return BottomSheetInfo(title: "내가 등록한 재치", sheetHeight: 219)
-        case .SearchWantTag:    return BottomSheetInfo(title: "내가 찾는 재치", sheetHeight: 219)
-        case .Category:         return BottomSheetInfo(title: "카테고리", sheetHeight: 524)
-        case .TownArea:         return BottomSheetInfo(title: "동네 범위 설정", sheetHeight: 442)
-        case .Declaration:      return BottomSheetInfo(title: "", sheetHeight: 128)
-        case .MakeMeeting:      return BottomSheetInfo(title: "주소검색", sheetHeight: 324)
-        case .LocationChange:   return BottomSheetInfo(title: "내 동네 변경하기", sheetHeight: 216)
-        }
-    }
-    
-    var sheetHeight: CGFloat{
-        return self.info.sheetHeight
-    }
-    
-    var title: String?{
-        return self.info.title
-    }
-    
-    var grabberVisibility: Bool{
-        return self.info.grabberVisibility
-    }
-    
-}


### PR DESCRIPTION
## What is this PR? 🔍
#136: BottomSheetInfo 파일 분리

## Key Changes 🔑
1. BottomSheetInfo 파일 생성
   - 원래 SheetViewController 안에서 관리하려고 했는데, 내부에서는 extension이 불가능해서.. 굳이 같은 파일에 넣을 필요가 없어졌네요..
   - 보기 쉽게 타입 정보 담고 있는 열거형/구조체 파일 새로 생성했습니다~

## To Reviewers 📢
- 파일 새로 추가되었으니 풀...받아주세여...
