### PR TITLE
Refactor/#206: 재치 검색 ViewModel 역할 확장 및 Clean Architecture 적용 완료

### DIFF
--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -271,6 +271,8 @@
 		EE27C54729C8273C00285CC5 /* FindWantZatchSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54629C8273C00285CC5 /* FindWantZatchSearchViewModel.swift */; };
 		EE27C54A29C8280A00285CC5 /* PopularKeywordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54929C8280A00285CC5 /* PopularKeywordUseCase.swift */; };
 		EE27C54C29C8286B00285CC5 /* SearchRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54B29C8286B00285CC5 /* SearchRepository.swift */; };
+		EE27C54E29C890BB00285CC5 /* ZatchSearchResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54D29C890BB00285CC5 /* ZatchSearchResultViewModel.swift */; };
+		EE27C55029C892D700285CC5 /* SearchResultUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54F29C892D700285CC5 /* SearchResultUseCase.swift */; };
 		EE2801BC29C6F07E003595A5 /* GetRegisterZatchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2801BB29C6F07E003595A5 /* GetRegisterZatchUseCase.swift */; };
 		EE2801BE29C6F0AD003595A5 /* LookingForZatchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2801BD29C6F0AD003595A5 /* LookingForZatchUseCase.swift */; };
 		EE2BC348298295C3002B5C60 /* EtcButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BC347298295C3002B5C60 /* EtcButton.swift */; };
@@ -654,6 +656,8 @@
 		EE27C54629C8273C00285CC5 /* FindWantZatchSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindWantZatchSearchViewModel.swift; sourceTree = "<group>"; };
 		EE27C54929C8280A00285CC5 /* PopularKeywordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularKeywordUseCase.swift; sourceTree = "<group>"; };
 		EE27C54B29C8286B00285CC5 /* SearchRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepository.swift; sourceTree = "<group>"; };
+		EE27C54D29C890BB00285CC5 /* ZatchSearchResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZatchSearchResultViewModel.swift; sourceTree = "<group>"; };
+		EE27C54F29C892D700285CC5 /* SearchResultUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultUseCase.swift; sourceTree = "<group>"; };
 		EE2801BB29C6F07E003595A5 /* GetRegisterZatchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRegisterZatchUseCase.swift; sourceTree = "<group>"; };
 		EE2801BD29C6F0AD003595A5 /* LookingForZatchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookingForZatchUseCase.swift; sourceTree = "<group>"; };
 		EE2BC347298295C3002B5C60 /* EtcButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EtcButton.swift; sourceTree = "<group>"; };
@@ -1904,6 +1908,7 @@
 			isa = PBXGroup;
 			children = (
 				EE27C54929C8280A00285CC5 /* PopularKeywordUseCase.swift */,
+				EE27C54F29C892D700285CC5 /* SearchResultUseCase.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -2187,6 +2192,7 @@
 			children = (
 				EEE326AF2998C6DF0017DF46 /* ExchangeMyZatchSearchViewModel.swift */,
 				EE27C54629C8273C00285CC5 /* FindWantZatchSearchViewModel.swift */,
+				EE27C54D29C890BB00285CC5 /* ZatchSearchResultViewModel.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -2540,6 +2546,7 @@
 				57A28B3D28CED93700263079 /* MapTownViewController.swift in Sources */,
 				576341C428D40A200067D2C5 /* TownMapAlertViewController.swift in Sources */,
 				23B051CC28E23B0C005D08EA /* AnswerTableViewCell.swift in Sources */,
+				EE27C55029C892D700285CC5 /* SearchResultUseCase.swift in Sources */,
 				5724EC8F291E0E9B00DC529B /* LoginView.swift in Sources */,
 				234E5DBC28C762810079640F /* TabBarViewController.swift in Sources */,
 				23CB3CF728C7D38F00C42858 /* MyZatchTabViewController.swift in Sources */,
@@ -2772,6 +2779,7 @@
 				57EBCE4828AA064C00212D20 /* RegisterImageDetailViewController.swift in Sources */,
 				57B32C3829220EA10018C0CB /* BottomSheetSystem.swift in Sources */,
 				57EBCE3E28A88EF200212D20 /* BasicAlertViewController.swift in Sources */,
+				EE27C54E29C890BB00285CC5 /* ZatchSearchResultViewModel.swift in Sources */,
 				57600C132963085E00A7F27B /* GatchDetailInfomationTableViewCell.swift in Sources */,
 				57B32C31291F56120018C0CB /* ZatchRegisterModel.swift in Sources */,
 				57C23CCD28B1D93E006E7915 /* ChatEtcBtnView.swift in Sources */,

--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -267,6 +267,12 @@
 		D1533A389FEC70B77AD110F6 /* Pods_ZatchTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2828C8E20374F7AEAB414182 /* Pods_ZatchTests.framework */; };
 		EE0D8E4B29B73CE000D96050 /* NoticeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D8E4A29B73CE000D96050 /* NoticeDetailView.swift */; };
 		EE0D8E4D29B7561200D96050 /* TableOnlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D8E4C29B7561200D96050 /* TableOnlyView.swift */; };
+		EE27C54529C826E000285CC5 /* SearchRepositotyInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54429C826E000285CC5 /* SearchRepositotyInterface.swift */; };
+		EE27C54729C8273C00285CC5 /* FindWantZatchSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54629C8273C00285CC5 /* FindWantZatchSearchViewModel.swift */; };
+		EE27C54A29C8280A00285CC5 /* PopularKeywordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54929C8280A00285CC5 /* PopularKeywordUseCase.swift */; };
+		EE27C54C29C8286B00285CC5 /* SearchRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54B29C8286B00285CC5 /* SearchRepository.swift */; };
+		EE2801BC29C6F07E003595A5 /* GetRegisterZatchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2801BB29C6F07E003595A5 /* GetRegisterZatchUseCase.swift */; };
+		EE2801BE29C6F0AD003595A5 /* LookingForZatchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2801BD29C6F0AD003595A5 /* LookingForZatchUseCase.swift */; };
 		EE2BC348298295C3002B5C60 /* EtcButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BC347298295C3002B5C60 /* EtcButton.swift */; };
 		EE2BC34A29829A32002B5C60 /* CenterNavigationHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BC34929829A32002B5C60 /* CenterNavigationHeaderView.swift */; };
 		EE2BC34D2982B067002B5C60 /* EtcButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BC34C2982B067002B5C60 /* EtcButtonHeaderView.swift */; };
@@ -644,6 +650,12 @@
 		E93BEB6442FCA2A68AFE12C0 /* Pods-Zatch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zatch.debug.xcconfig"; path = "Target Support Files/Pods-Zatch/Pods-Zatch.debug.xcconfig"; sourceTree = "<group>"; };
 		EE0D8E4A29B73CE000D96050 /* NoticeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeDetailView.swift; sourceTree = "<group>"; };
 		EE0D8E4C29B7561200D96050 /* TableOnlyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableOnlyView.swift; sourceTree = "<group>"; };
+		EE27C54429C826E000285CC5 /* SearchRepositotyInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositotyInterface.swift; sourceTree = "<group>"; };
+		EE27C54629C8273C00285CC5 /* FindWantZatchSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindWantZatchSearchViewModel.swift; sourceTree = "<group>"; };
+		EE27C54929C8280A00285CC5 /* PopularKeywordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularKeywordUseCase.swift; sourceTree = "<group>"; };
+		EE27C54B29C8286B00285CC5 /* SearchRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepository.swift; sourceTree = "<group>"; };
+		EE2801BB29C6F07E003595A5 /* GetRegisterZatchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRegisterZatchUseCase.swift; sourceTree = "<group>"; };
+		EE2801BD29C6F0AD003595A5 /* LookingForZatchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookingForZatchUseCase.swift; sourceTree = "<group>"; };
 		EE2BC347298295C3002B5C60 /* EtcButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EtcButton.swift; sourceTree = "<group>"; };
 		EE2BC34929829A32002B5C60 /* CenterNavigationHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterNavigationHeaderView.swift; sourceTree = "<group>"; };
 		EE2BC34C2982B067002B5C60 /* EtcButtonHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EtcButtonHeaderView.swift; sourceTree = "<group>"; };
@@ -995,6 +1007,7 @@
 				57A28D5328D19D3700263079 /* KakaoDataManager */,
 				EE813FFA29C585370091F16E /* ZatchRepository.swift */,
 				EE813FFC29C585400091F16E /* UserRepository.swift */,
+				EE27C54B29C8286B00285CC5 /* SearchRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -1887,6 +1900,14 @@
 			path = Notice;
 			sourceTree = "<group>";
 		};
+		EE27C54829C827EF00285CC5 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				EE27C54929C8280A00285CC5 /* PopularKeywordUseCase.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
 		EE2BC34B2982B01E002B5C60 /* TabBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -2020,6 +2041,7 @@
 			children = (
 				EE7B76BF29C5E36D00942798 /* ZatchRepositoryInterface.swift */,
 				EE7B76C029C5E36D00942798 /* UserRepositoryInterface.swift */,
+				EE27C54429C826E000285CC5 /* SearchRepositotyInterface.swift */,
 			);
 			path = RepositoryInterface;
 			sourceTree = "<group>";
@@ -2034,6 +2056,7 @@
 		EE7B76CF29C5F61C00942798 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				EE27C54829C827EF00285CC5 /* Search */,
 				EE7B76D029C5F61C00942798 /* Zatch */,
 				EE7B76D429C5F61C00942798 /* User */,
 			);
@@ -2046,6 +2069,8 @@
 				EE7B76D129C5F61C00942798 /* HeartZatchUseCase.swift */,
 				EE7B76D229C5F61C00942798 /* AroundZatchUseCase.swift */,
 				EE7B76D329C5F61C00942798 /* PopularZatchUseCase.swift */,
+				EE2801BB29C6F07E003595A5 /* GetRegisterZatchUseCase.swift */,
+				EE2801BD29C6F0AD003595A5 /* LookingForZatchUseCase.swift */,
 			);
 			path = Zatch;
 			sourceTree = "<group>";
@@ -2161,6 +2186,7 @@
 			isa = PBXGroup;
 			children = (
 				EEE326AF2998C6DF0017DF46 /* ExchangeMyZatchSearchViewModel.swift */,
+				EE27C54629C8273C00285CC5 /* FindWantZatchSearchViewModel.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -2603,12 +2629,15 @@
 				5767D78D286C4AB70075DB28 /* ZatchTextRadioButton.swift in Sources */,
 				576EA925282B7FBB0028046C /* ZatchRegisterSecondViewController.swift in Sources */,
 				57468A90289FEF3200056691 /* SearchTagSheetViewController.swift in Sources */,
+				EE27C54A29C8280A00285CC5 /* PopularKeywordUseCase.swift in Sources */,
 				576B376128D82F7300EF36E6 /* UserLeaveView.swift in Sources */,
 				EEE326B02998C6DF0017DF46 /* ExchangeMyZatchSearchViewModel.swift in Sources */,
 				EEB13B94297FCD0A001A8DD9 /* LifeCycle+Rx.swift in Sources */,
 				576B375F28D82F6400EF36E6 /* UserLeaveViewController.swift in Sources */,
+				EE27C54C29C8286B00285CC5 /* SearchRepository.swift in Sources */,
 				57D6D79928CDBC6000F805B7 /* ModifyMeetingSheetView.swift in Sources */,
 				57B32C2C291F49CF0018C0CB /* ZatchRegisterFirstView.swift in Sources */,
+				EE27C54729C8273C00285CC5 /* FindWantZatchSearchViewModel.swift in Sources */,
 				579F5E58281E574200D3F0D5 /* FindWantZatchSearchViewController.swift in Sources */,
 				57E75EC528E3C4CE00AC24B2 /* ShareDetailTableViewCell.swift in Sources */,
 				576B376A28D846CB00EF36E6 /* SettingBorderLineTableViewCell.swift in Sources */,
@@ -2626,6 +2655,7 @@
 				57D6D79F28CDC02600F805B7 /* ModifyMeetingSheetViewController.swift in Sources */,
 				57E75EC728E5480A00AC24B2 /* ExchangeMyZatchSearchView.swift in Sources */,
 				EE2BC34D2982B067002B5C60 /* EtcButtonHeaderView.swift in Sources */,
+				EE2801BE29C6F0AD003595A5 /* LookingForZatchUseCase.swift in Sources */,
 				EE410197298557440083B7E0 /* ImageDetailView.swift in Sources */,
 				57468AA028A214FD00056691 /* UILabel.swift in Sources */,
 				5722461428C230B3009B7C78 /* PickerAlertViewController.swift in Sources */,
@@ -2754,6 +2784,7 @@
 				EE813FE029C445B90091F16E /* StrokeTag.swift in Sources */,
 				571DADC7297BAE030079CCD3 /* BaseTabBarHeaderView.swift in Sources */,
 				5724EB61290FC1BB00DC529B /* ModifyMeetingAlertController.swift in Sources */,
+				EE27C54529C826E000285CC5 /* SearchRepositotyInterface.swift in Sources */,
 				EEE7F2B5299BD83C00C674B9 /* ZatchExchangeTableViewCell.swift in Sources */,
 				EEB13B8B297FBBAE001A8DD9 /* DefaultObservable.swift in Sources */,
 				EEB13B8D297FC68B001A8DD9 /* UIButton+Rx.swift in Sources */,
@@ -2763,6 +2794,7 @@
 				EE41019529854EE60083B7E0 /* LeftNavigationEtcButtonHeaderView.swift in Sources */,
 				23E764CE28E9EF10002F234C /* ServiceCenterTabmanViewController.swift in Sources */,
 				57C23CD228B231E5006E7915 /* ChattingSideSheetViewController.swift in Sources */,
+				EE2801BC29C6F07E003595A5 /* GetRegisterZatchUseCase.swift in Sources */,
 				EE661A43299D0DF7002904A7 /* CenterAlignCollectionViewFlowLayout.swift in Sources */,
 				23B051B928E1FDCC005D08EA /* NotificationView.swift in Sources */,
 				EE813FDE29C445B30091F16E /* FilledTag.swift in Sources */,

--- a/Zatch/Data/Repository/SearchRepository.swift
+++ b/Zatch/Data/Repository/SearchRepository.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 class SearchRepository: SearchRepositotyInterface{
+    func getSearchResult() {
+        
+    }
+    
     func getPopularKeyword() {
     }
 }

--- a/Zatch/Data/Repository/SearchRepository.swift
+++ b/Zatch/Data/Repository/SearchRepository.swift
@@ -1,0 +1,13 @@
+//
+//  SearchRepository.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/03/20.
+//
+
+import Foundation
+
+class SearchRepository: SearchRepositotyInterface{
+    func getPopularKeyword() {
+    }
+}

--- a/Zatch/Data/Repository/ZatchRepository.swift
+++ b/Zatch/Data/Repository/ZatchRepository.swift
@@ -8,6 +8,14 @@
 import Foundation
 
 final class ZatchRepository: ZatchRepositoryInterface {
+    func getRegisterZatch() {
+        
+    }
+    
+    func getLookingForZatch() {
+        
+    }
+    
     func getPopularZatch(){
         
     }

--- a/Zatch/Domain/RepositoryInterface/SearchRepositotyInterface.swift
+++ b/Zatch/Domain/RepositoryInterface/SearchRepositotyInterface.swift
@@ -1,0 +1,12 @@
+//
+//  SearchRepositotyInterface.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/03/20.
+//
+
+import Foundation
+
+protocol SearchRepositotyInterface{
+    func getPopularKeyword()
+}

--- a/Zatch/Domain/RepositoryInterface/SearchRepositotyInterface.swift
+++ b/Zatch/Domain/RepositoryInterface/SearchRepositotyInterface.swift
@@ -9,4 +9,5 @@ import Foundation
 
 protocol SearchRepositotyInterface{
     func getPopularKeyword()
+    func getSearchResult()
 }

--- a/Zatch/Domain/RepositoryInterface/ZatchRepositoryInterface.swift
+++ b/Zatch/Domain/RepositoryInterface/ZatchRepositoryInterface.swift
@@ -11,4 +11,6 @@ protocol ZatchRepositoryInterface {
     func getPopularZatch()
     func getAroundZatch()
     func fetchHeartState()
+    func getRegisterZatch()
+    func getLookingForZatch()
 }

--- a/Zatch/Domain/UseCase/Search/PopularKeywordUseCase.swift
+++ b/Zatch/Domain/UseCase/Search/PopularKeywordUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  PopularKeywordUseCase.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/03/20.
+//
+
+import Foundation
+
+struct PopularKeywordRequestValue {
+}
+
+protocol PopularKeywordUseCaseInterface {
+    func execute(requestValue: PopularKeywordRequestValue) async throws
+}
+
+final class PopularKeywordUseCase: PopularKeywordUseCaseInterface {
+
+    private let searchRepository: SearchRepositotyInterface
+
+    init(searchRepository: SearchRepositotyInterface = SearchRepository()) {
+        self.searchRepository = searchRepository
+    }
+
+    func execute(requestValue: PopularKeywordRequestValue) async throws {
+        return try await searchRepository.getPopularKeyword()
+    }
+}

--- a/Zatch/Domain/UseCase/Search/SearchResultUseCase.swift
+++ b/Zatch/Domain/UseCase/Search/SearchResultUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  SearchResultUseCase.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/03/20.
+//
+
+import Foundation
+
+struct SearchResultRequestValue {
+}
+
+protocol SearchResultUseCaseInterface {
+    func execute(requestValue: SearchResultRequestValue) async throws
+}
+
+final class SearchResultUseCase: SearchResultUseCaseInterface {
+
+    private let searchRepository: SearchRepositotyInterface
+
+    init(searchRepository: SearchRepositotyInterface = SearchRepository()) {
+        self.searchRepository = searchRepository
+    }
+
+    func execute(requestValue: SearchResultRequestValue) async throws {
+        return try await searchRepository.getSearchResult()
+    }
+}

--- a/Zatch/Domain/UseCase/Zatch/GetRegisterZatchUseCase.swift
+++ b/Zatch/Domain/UseCase/Zatch/GetRegisterZatchUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  GetMyZatchUseCase.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/03/19.
+//
+
+import Foundation
+
+struct GetRegisterZatchRequestValue {
+    
+}
+
+protocol GetRegisterZatchUseCaseInterface {
+    func execute(requestValue: GetRegisterZatchRequestValue) async throws
+}
+
+final class GetRegisterZatchUseCase: GetRegisterZatchUseCaseInterface {
+
+    private let zatchRepository: ZatchRepositoryInterface
+
+    init(zatchRepository: ZatchRepositoryInterface = ZatchRepository()) {
+        self.zatchRepository = zatchRepository
+    }
+
+    func execute(requestValue: GetRegisterZatchRequestValue) async throws {
+        return try await zatchRepository.getRegisterZatch()
+    }
+}

--- a/Zatch/Domain/UseCase/Zatch/LookingForZatchUseCase.swift
+++ b/Zatch/Domain/UseCase/Zatch/LookingForZatchUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  LookingForZatchUseCase.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/03/19.
+//
+
+import Foundation
+
+struct LookingForZatchRequestValue {
+    
+}
+
+protocol LookingForZatchUseCaseInterface {
+    func execute(requestValue: LookingForZatchRequestValue) async throws
+}
+
+final class LookingForZatchUseCase: LookingForZatchUseCaseInterface {
+
+    private let zatchRepository: ZatchRepositoryInterface
+
+    init(zatchRepository: ZatchRepositoryInterface = ZatchRepository()) {
+        self.zatchRepository = zatchRepository
+    }
+
+    func execute(requestValue: LookingForZatchRequestValue) async throws {
+        return try await zatchRepository.getLookingForZatch()
+    }
+}

--- a/Zatch/Global/Source/BottomSheet/BaseBottomSheetViewController.swift
+++ b/Zatch/Global/Source/BottomSheet/BaseBottomSheetViewController.swift
@@ -51,8 +51,8 @@ class BaseBottomSheetViewController<T>: UIViewController, UIViewControllerTransi
     }
     
     func style(){
-        self.view.backgroundColor = .white
-        self.navigationController?.isNavigationBarHidden = true
+        view.backgroundColor = .white
+        navigationController?.isNavigationBarHidden = true
     }
     
     func initialize() {
@@ -71,7 +71,7 @@ class BaseBottomSheetViewController<T>: UIViewController, UIViewControllerTransi
     
     @discardableResult
     func show(in viewController: UIViewController) -> Self{
-        self.loadViewIfNeeded()
+        loadViewIfNeeded()
         viewController.present(self, animated: true)
         return self
     }

--- a/Zatch/Presentation/Cells/SearchCells/Zatch/SearchMyZatchByRegisterCollectionViewCell.swift
+++ b/Zatch/Presentation/Cells/SearchCells/Zatch/SearchMyZatchByRegisterCollectionViewCell.swift
@@ -26,5 +26,4 @@ class SearchMyZatchByRegisterCollectionViewCell: BaseCollectionViewCell, SearchZ
         super.layout()
         tagLabelLayout()
     }
-    
 }

--- a/Zatch/Presentation/Cells/SearchCells/Zatch/SearchTagCollectionViewCell.swift
+++ b/Zatch/Presentation/Cells/SearchCells/Zatch/SearchTagCollectionViewCell.swift
@@ -40,7 +40,7 @@ class SearchTagCollectionViewCell: BaseCollectionViewCell{
         }
     }
     
-    static func getEstimatedSize(title: String) -> CGSize{
+    static func getEstimatedSize(of title: String) -> CGSize{
         
         let testLabel = PaddingLabel(padding: ZatchComponent.Padding(left: 14, right: 14, top: 6, bottom: 6)).then{
             $0.text = title

--- a/Zatch/Presentation/Cells/SearchCells/Zatch/SearchWantZatchByRegisterCollectionViewCell.swift
+++ b/Zatch/Presentation/Cells/SearchCells/Zatch/SearchWantZatchByRegisterCollectionViewCell.swift
@@ -26,5 +26,4 @@ class SearchWantZatchByRegisterCollectionViewCell: BaseCollectionViewCell, Searc
         super.layout()
         tagLabelLayout()
     }
-    
 }

--- a/Zatch/Presentation/Utils/Search/ZatchSearchRequestManager.swift
+++ b/Zatch/Presentation/Utils/Search/ZatchSearchRequestManager.swift
@@ -13,9 +13,11 @@ class ZatchSearchRequestManager{
     
     private init() { }
     
-    var myZatch: String = ""
+    var myProduct: String = ""
+    var wantProduct: String = ""
     
     func initialize(){
-        myZatch = ""
+        myProduct = ""
+        wantProduct = ""
     }
 }

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ExchangeMyZatchSearchViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ExchangeMyZatchSearchViewController.swift
@@ -14,7 +14,6 @@ class ExchangeMyZatchSearchViewController: BaseViewController<BaseHeaderView, Ex
     
     //MARK: - Properties
     
-    private let zatches = ["몰랑이 피규어","매일우유 250ml","콜드브루 60ml","예시가 있다면","이렇게 들어가야","해요요요요","해요요요","해요요","해요","해","아아앙아ㅏ앙아아앙아아"]
     private let viewModel = ExchangeMyZatchSearchViewModel()
     private let searchManager = ZatchSearchRequestManager.shared
     
@@ -32,38 +31,38 @@ class ExchangeMyZatchSearchViewController: BaseViewController<BaseHeaderView, Ex
         
         super.initialize()
         
-        mainView.collectionView.delegate = self
-        mainView.collectionView.dataSource = self
+        mainView.collectionView.initializeDelegate(self)
         
-        mainView.nextButton.addTarget(self, action: #selector(nextButtonClick), for: .touchUpInside)
+        mainView.nextButton.addTarget(self, action: #selector(moveNextButtonDidTapped), for: .touchUpInside)
         mainView.skipButton.addTarget(self, action: #selector(skipBtnDidClicked), for: .touchUpInside)
     }
     
     override func bind() {
         
-        let input = ExchangeMyZatchSearchViewModel.Input(exchangeProductName: mainView.searchTextFieldFrame.textField.rx.text.orEmpty.asObservable())
+        let input = ExchangeMyZatchSearchViewModel.Input(exchangeProductByTextField: mainView.searchTextFieldFrame.textField.rx.text.orEmpty.asObservable())
         let output = viewModel.transform(input)
         
         output.exchangeProductName
-            .drive{
-                self.searchManager.myZatch = $0
+            .drive{ [weak self] in
+                self?.mainView.searchTextFieldFrame.textField.text = $0
             }.disposed(by: disposeBag)
         
         output.canMoveNext
-            .drive(
-                self.mainView.nextButton.rx.isEnabled
-            ).disposed(by: disposeBag)
+            .drive(mainView.nextButton.rx.isEnabled)
+            .disposed(by: disposeBag)
+        
+        //cell 클릭으로 데이터 설정했다가 textField 입력 바꾸는 경우 > cell isSelectState toggle 시켜야
     }
     
     //MARK: Action
     
-    @objc func nextButtonClick(){
-        let vc = FindWantZatchSearchViewController(productName: searchManager.myZatch)
+    @objc private func moveNextButtonDidTapped(){
+        let vc = FindWantZatchSearchViewController(productName: searchManager.myProduct)
         self.navigationController?.pushViewController(vc, animated: true)
     }
     
-    @objc func skipBtnDidClicked(){
-        searchManager.myZatch = ""
+    @objc private func skipBtnDidClicked(){
+        viewModel.willSkipSelectMyZatch()
         let vc = FindWantZatchSearchViewController()
         self.navigationController?.pushViewController(vc, animated: true)
     }
@@ -72,12 +71,12 @@ class ExchangeMyZatchSearchViewController: BaseViewController<BaseHeaderView, Ex
 extension ExchangeMyZatchSearchViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout{
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        zatches.count
+        viewModel.getMyZatchesCount()
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         return collectionView.dequeueReusableCell(for: indexPath, cellType: SearchTagCollectionViewCell.self).then{
-            $0.setTitle(zatches[indexPath.row])
+            $0.setTitle(viewModel.getMyZatch(at: indexPath.row))
         }
     }
     
@@ -87,8 +86,7 @@ extension ExchangeMyZatchSearchViewController: UICollectionViewDelegate, UIColle
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath, cellType: SearchTagCollectionViewCell.self) else { return }
-        mainView.searchTextFieldFrame.textField.text = cell.isSelectState ? "" : zatches[indexPath.row]
-        mainView.searchTextFieldFrame.textField.sendActions(for: .valueChanged)
+        cell.isSelectState ? viewModel.willDeselectMyZatch() : viewModel.willSelectZatch(at: indexPath.row)
         cell.isSelectState.toggle()
     }
     

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ExchangeMyZatchSearchViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ExchangeMyZatchSearchViewController.swift
@@ -82,7 +82,7 @@ extension ExchangeMyZatchSearchViewController: UICollectionViewDelegate, UIColle
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        SearchTagCollectionViewCell.getEstimatedSize(title: zatches[indexPath.row])
+        SearchTagCollectionViewCell.getEstimatedSize(of: viewModel.getMyZatch(at: indexPath.row))
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
@@ -9,7 +9,11 @@ import UIKit
 
 class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchSearchResultView>, UIGestureRecognizerDelegate {
     
-    //MARK: - Properties
+    @frozen
+    enum ProductType{
+        case myProduct
+        case wantProduct
+    }
     
     private var myZatchIndex: Int?
     private var wantZatchIndex: Int?

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
@@ -200,10 +200,8 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
         //커서 올리기
         let textField: UITextField = {
             switch getProductType(of: recognizerView){
-            case .myProduct:
-                return mainView.myZatchFrame.productTextField
-            case .wantProduct:
-                return mainView.myZatchFrame.productTextField
+            case .myProduct:        return mainView.myZatchFrame.productTextField
+            case .wantProduct:      return mainView.wantZatchFrame.productTextField
             }
         }()
         

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
@@ -76,6 +76,24 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
                 self?.mainView.tableView.backgroundView?.isHidden = $0
             }.disposed(by: disposeBag)
         
+        output.myProductName
+            .drive{ [weak self] in
+                self?.mainView.myZatchFrame.productLabel.text = $0
+            }.disposed(by: disposeBag)
+        
+        output.wantProductName
+            .drive{ [weak self] in
+                self?.mainView.wantZatchFrame.productLabel.text = $0
+            }.disposed(by: disposeBag)
+        
+        output.isMyProductCategorySelect
+            .drive(mainView.myZatchFrame.categortBtn.rx.isSelected)
+            .disposed(by: disposeBag)
+        
+        output.isWantProductCategorySelect
+            .drive(mainView.wantZatchFrame.categortBtn.rx.isSelected)
+            .disposed(by: disposeBag)
+        
         mainView.townFrame.rx.tapGesture()
             .when(.recognized)
             .bind(onNext: { [weak self] _ in

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
@@ -6,6 +6,9 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
+import RxGesture
 
 class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchSearchResultView>, UIGestureRecognizerDelegate {
     
@@ -15,17 +18,20 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
         case wantProduct
     }
     
-    private var myZatchIndex: Int?
-    private var wantZatchIndex: Int?
-    private var resultData = [String](){
+    private var isProductNameEditing: Bool = false{
         didSet{
-            if(resultData.isEmpty){
-                mainView.tableView.backgroundView?.isHidden = false
-            }else{
-                mainView.tableView.backgroundView?.isHidden = true
-            }
+            changeProductTextFieldHiddenState()
+            changeProductLabelHiddenState()
         }
     }
+    private lazy var productFrames: [ZatchSearchResultView.SearchFieldFrame] = [mainView.myZatchFrame, mainView.wantZatchFrame]
+
+    //MARK: - Properties
+    
+    private let viewModel = ZatchSearchResultViewModel()
+    private let registerZatchBottomSheetInstance = SearchMyRegisterZatchSheetViewController()
+    private let lookingForZatchBottomSheetInstance = SearchWantRegisterZatchSheetViewController()
+    private let categoryBottomSheet = CategorySheetViewController()
     
     init(){
         super.init(headerView: BaseHeaderView(), mainView: ZatchSearchResultView())
@@ -43,99 +49,195 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
         
         super.initialize()
         
-        mainView.tableView.separatorStyle = .none
-        mainView.tableView.dataSource = self
-        mainView.tableView.delegate = self
-
-        mainView.myZatchFrame.productTextField.delegate = self
-        mainView.wantZatchFrame.productTextField.delegate = self
+        setTagWithProductType()
         
-        mainView.myZatchFrame.categortBtn.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(openCategoryBottomSheet)))
-        mainView.myZatchFrame.productLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(openMyZatchBottomSheet)))
-        mainView.myZatchFrame.productLabel.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(textFieldDidPressedLong)))
+        mainView.tableView.initializeDelegate(self)
+    }
+    
+    private func setTagWithProductType(){
+        let myZatchFrame = mainView.myZatchFrame
+        [myZatchFrame, myZatchFrame.productLabel, myZatchFrame.categortBtn].forEach{
+            $0.tag = ProductType.myProduct.tag
+        }
         
-        mainView.wantZatchFrame.categortBtn.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(openCategoryBottomSheet)))
-        mainView.wantZatchFrame.productLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(openWantZatchBottomSheet)))
-        mainView.wantZatchFrame.productLabel.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(textFieldDidPressedLong)))
+        let wantZatchFrame = mainView.wantZatchFrame
+        [wantZatchFrame, wantZatchFrame.productLabel, wantZatchFrame.categortBtn].forEach{
+            $0.tag = ProductType.wantProduct.tag
+        }
+    }
+    
+    override func bind() {
         
-        mainView.townFrame.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(townFrameDidClicked)))
+        let input = ZatchSearchResultViewModel.Input()
+        let output = viewModel.transform(input)
+        
+        output.willEmptyViewHidden
+            .drive{ [weak self] in
+                self?.mainView.tableView.backgroundView?.isHidden = $0
+            }.disposed(by: disposeBag)
+        
+        mainView.townFrame.rx.tapGesture()
+            .when(.recognized)
+            .bind(onNext: { [weak self] _ in
+                self?.townSettingBottomSheetWillShow()
+            }).disposed(by: disposeBag)
+        
+        setProductFramesRx()
+        
+        setMyZatchFrameGestureRecognizer()
+        setWantZatchFrameGestureRecognizer()
+    }
+    
+    private func setProductFramesRx(){
+        
+        productFrames.forEach{
+            //Category
+            $0.categortBtn.rx.tapGesture()
+                .when(.recognized)
+                .bind(onNext: { [weak self] in
+                    self?.willShowCategoryBottomSheet(recognizer: $0)
+                }).disposed(by: disposeBag)
+            
+            //TextField
+            $0.productTextField.rx.controlEvent([.editingDidEndOnExit])
+                .bind(onNext: { [weak self] in
+                    self?.productTextFieldDidPressReturnKey()
+                }).disposed(by: disposeBag)
+        }
+    }
+    
+    private func setMyZatchFrameGestureRecognizer(){
+        
+//        mainView.myZatchFrame.productLabel.rx.tapGesture()
+//            .when(.recognized)
+//            .bind{ [weak self] _ in
+//                print("tap test")
+//                self?.openMyZatchBottomSheet()
+//            }.disposed(by: disposeBag)
+//
+//        mainView.myZatchFrame.productLabel.rx.longPressGesture()
+//            .when(.recognized)
+//            .bind{ [weak self] in
+//                print("long press test")
+//                self?.textFieldDidPressedLong($0)
+//            }.disposed(by: disposeBag)
+        
+        mainView.myZatchFrame.productLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(willShowZatchBottomSheet(_:))))
+        mainView.myZatchFrame.productLabel.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(productNameTextFieldWillShow)))
+    }
+    
+    private func setWantZatchFrameGestureRecognizer(){
+        
+//        mainView.wantZatchFrame.productLabel.rx.longPressGesture()
+//            .when(.recognized)
+//            .bind{ [weak self] in
+//                self?.textFieldDidPressedLong($0)
+//            }.disposed(by: disposeBag)
+//
+//        mainView.wantZatchFrame.productLabel.rx.tapGesture()
+//            .when(.recognized)
+//            .bind{ [weak self] _ in
+//                self?.openWantZatchBottomSheet()
+//            }.disposed(by: disposeBag)
+        
+        mainView.wantZatchFrame.productLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(willShowZatchBottomSheet(_:))))
+        mainView.wantZatchFrame.productLabel.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(productNameTextFieldWillShow)))
+    }
+    
+    private func getProductType(of: UIView) -> ProductType{
+        switch of.tag{
+        case ProductType.myProduct.tag:         return .myProduct
+        case ProductType.wantProduct.tag:       return .wantProduct
+        default:                                fatalError()
+        }
+    }
+    
+    @objc private func willShowZatchBottomSheet(_ recognizer: UITapGestureRecognizer){
+        if let recognizeView = recognizer.view{
+            switch getProductType(of: recognizeView){
+            case .myProduct:
+                registerZatchBottomSheetInstance.show(in: self)
+            case .wantProduct:
+                lookingForZatchBottomSheetInstance.show(in: self)
+            }
+        }
+    }
+    
+    @objc private func willShowCategoryBottomSheet(recognizer: UITapGestureRecognizer){
+        categoryBottomSheet.show(in: self)
+        categoryBottomSheet.completion = { [weak self] categoryId in
+            if let categoryButton = recognizer.view as? ZatchSearchResultView.SearchCateogryDotButton{
+                categoryButton.isSelected = true
+                self?.setCategoryIdWithCheckProductType(of: categoryButton, categoryId: categoryId)
+            }
+        }
+    }
+    
+    private func setCategoryIdWithCheckProductType(of view: UIView, categoryId: Int) {
+        switch getProductType(of: view){
+        case .myProduct:
+            viewModel.setMyProductCategory(id: categoryId)
+        case .wantProduct:
+            viewModel.setWantProductCategory(id: categoryId)
+        }
     }
     
     //TextField 입력 끝나거나 취소됐을 경우
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-
-        mainView.myZatchFrame.productTextField.isHidden = true
-        mainView.wantZatchFrame.productTextField.isHidden = true
-
-        mainView.myZatchFrame.productLabel.isHidden = false
-        mainView.wantZatchFrame.productLabel.isHidden = false
+        isProductNameEditing = false
+        view.endEditing(true)
+    }
+    
+    @objc func productNameTextFieldWillShow(_ recognizer : UIGestureRecognizer){
         
-        self.view.endEditing(true)
-    }
-    
-    //MARK: Action
-    
-    @objc func openMyZatchBottomSheet(recognizer: UITapGestureRecognizer){
-        let bottomSheet = SearchMyRegisterZatchSheetViewController().show(in: self)
-        bottomSheet.currentTag = myZatchIndex
-        bottomSheet.completion = {
-//            self.mainView.myZatchFrame.productLabel.text = text
-            self.myZatchIndex = $0
-        }
-    }
-    
-    @objc func openWantZatchBottomSheet(recognizer: UITapGestureRecognizer){
-        let bottomSheet = SearchWantRegisterZatchSheetViewController().show(in: self)
-        bottomSheet.currentTag = wantZatchIndex
-        bottomSheet.completion = {
-//            self.mainView.wantZatchFrame.productLabel.text = text
-            self.wantZatchIndex = $0
-        }
-    }
-    
-    @objc func openCategoryBottomSheet(recognizer: UITapGestureRecognizer){
-        let vc = CategorySheetViewController(service: .Zatch).show(in: self)
-        vc.completion = { category in
-            print(category)
-            (recognizer.view as? ZatchSearchResultView.SearchCateogryDotButton)?.isSelected = true
-        }
-    }
-    
-    @objc func textFieldDidPressedLong(_ recognizer : UIGestureRecognizer){
+        guard let recognizerView = recognizer.view else { return }
+        
+        isProductNameEditing = true
+        
         //기존 입력값 초기화
-        mainView.myZatchFrame.productTextField.text = nil
-        mainView.wantZatchFrame.productTextField.text = nil
-
-        mainView.myZatchFrame.productTextField.placeholder = mainView.myZatchFrame.productLabel.text
-        mainView.wantZatchFrame.productTextField.placeholder = mainView.wantZatchFrame.productLabel.text
-
-        mainView.myZatchFrame.productTextField.setPlaceholderColor(.black10)
-        mainView.wantZatchFrame.productTextField.setPlaceholderColor(.black10)
-
-        mainView.myZatchFrame.productTextField.isHidden = false
-        mainView.wantZatchFrame.productTextField.isHidden = false
-
-        mainView.myZatchFrame.productLabel.isHidden = true
-        mainView.wantZatchFrame.productLabel.isHidden = true
+        initializeTextField()
 
         //커서 올리기
-        if(recognizer.view == mainView.wantZatchFrame.productLabel){
-            mainView.wantZatchFrame.productTextField.becomeFirstResponder()
-        }else{
-            mainView.myZatchFrame.productTextField.becomeFirstResponder()
+        let textField: UITextField = {
+            switch getProductType(of: recognizerView){
+            case .myProduct:
+                return mainView.myZatchFrame.productTextField
+            case .wantProduct:
+                return mainView.myZatchFrame.productTextField
+            }
+        }()
+        
+        textField.becomeFirstResponder()
+    }
+    
+    private func initializeTextField(){
+        productFrames.forEach{
+            $0.productTextField.text = nil
+            $0.productTextField.placeholder = $0.productLabel.text
         }
     }
     
-    @objc func townFrameDidClicked(){
+    private func productTextFieldDidPressReturnKey(){
+        isProductNameEditing = false
+    }
+    
+    private func changeProductTextFieldHiddenState(){
+        productFrames.forEach{
+            $0.productTextField.isHidden = !isProductNameEditing
+        }
+    }
+    
+    private func changeProductLabelHiddenState(){
+        productFrames.forEach{
+            $0.productLabel.isHidden = isProductNameEditing
+        }
+    }
+    
+    @objc func townSettingBottomSheetWillShow(){
         let vc = TownSettingSheetViewController().show(in: self)
         vc.completion = { town in
             print(town)
-//            (recognizer.view as? SearchCateogryDotButton)?.isSelected = true
         }
-    }
-    
-    override func viewControllerWillPop() {
-        self.navigationController?.popToRootViewController(animated: true)
     }
 
 }
@@ -143,44 +245,33 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
 extension ZatchSearchResultViewController: UITableViewDelegate, UITableViewDataSource{
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 0
+        viewModel.getSearchResultCount()
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        //임시 조건문 설정
+        let data = viewModel.getZatch(at: indexPath.row)
         if(indexPath.row < 5){
-            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: ZatchShareTableViewCell.self)
-            cell.bindingData()
-            return cell
+            return tableView.dequeueReusableCell(for: indexPath, cellType: ZatchShareTableViewCell.self).then{
+                $0.bindingData()
+            }
         }else{
-            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: ZatchExchangeTableViewCell.self)
-            cell.bindingData()
-            return cell
+            return tableView.dequeueReusableCell(for: indexPath, cellType: ZatchExchangeTableViewCell.self).then{
+                $0.bindingData()
+            }
         }
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let vc = ZatchDetailViewController()
-        self.navigationController?.pushViewController(vc, animated: true)
+        navigationController?.pushViewController(ZatchDetailViewController(), animated: true)
     }
 }
 
-extension ZatchSearchResultViewController: UITextFieldDelegate{
-    
-    //return 키 클릭시 호출 메서드
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        mainView.myZatchFrame.productTextField.isHidden = true
-        mainView.wantZatchFrame.productTextField.isHidden = true
-
-        mainView.myZatchFrame.productLabel.isHidden = false
-        mainView.wantZatchFrame.productLabel.isHidden = false
-
-        if(textField == mainView.myZatchFrame.productTextField){
-            mainView.myZatchFrame.productLabel.text = mainView.myZatchFrame.productTextField.text
-        }else{
-            mainView.wantZatchFrame.productLabel.text = mainView.wantZatchFrame.productTextField.text
+extension ZatchSearchResultViewController.ProductType{
+    var tag: Int{
+        switch self{
+        case .myProduct:        return 100
+        case .wantProduct:      return 200
         }
-        
-        self.view.endEditing(true)
-        return true
     }
 }

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
@@ -192,24 +192,23 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
         guard let recognizerView = recognizer.view else { return }
         
         isProductNameEditing = true
-        
         //기존 입력값 초기화
         initializeTextField()
-
         //커서 올리기
-        let textField: UITextField = {
-            switch getProductType(of: recognizerView){
-            case .myProduct:        return mainView.myZatchFrame.productTextField
-            case .wantProduct:      return mainView.wantZatchFrame.productTextField
-            }
-        }()
-        textField.becomeFirstResponder()
+        getProductTextField(from: recognizerView).becomeFirstResponder()
     }
     
     private func initializeTextField(){
         productFrames.forEach{
             $0.productTextField.text = nil
             $0.productTextField.placeholder = $0.productLabel.text
+        }
+    }
+    
+    private func getProductTextField(from recognizeView: UIView) -> UITextField{
+        switch getProductType(of: recognizeView){
+        case .myProduct:        return mainView.myZatchFrame.productTextField
+        case .wantProduct:      return mainView.wantZatchFrame.productTextField
         }
     }
     

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
@@ -116,6 +116,8 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
             //TextField
             $0.productTextField.rx.controlEvent([.editingDidEndOnExit])
                 .bind(onNext: { [weak self] in
+                    self?.viewModel.pressTextFieldReturnKey(myProduct: self?.mainView.myZatchFrame.productTextField.text,
+                                                            wantProduct: self?.mainView.wantZatchFrame.productTextField.text)
                     self?.productTextFieldDidPressReturnKey()
                 }).disposed(by: disposeBag)
             

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
@@ -24,14 +24,13 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
             changeProductLabelHiddenState()
         }
     }
-    private lazy var productFrames: [ZatchSearchResultView.SearchFieldFrame] = [mainView.myZatchFrame, mainView.wantZatchFrame]
-
-    //MARK: - Properties
     
     private let viewModel = ZatchSearchResultViewModel()
-    private let registerZatchBottomSheetInstance = SearchMyRegisterZatchSheetViewController()
-    private let lookingForZatchBottomSheetInstance = SearchWantRegisterZatchSheetViewController()
     private let categoryBottomSheet = CategorySheetViewController()
+    
+    private lazy var registerZatchBottomSheetInstance = SearchMyRegisterZatchSheetViewController(viewModel: viewModel)
+    private lazy var lookingForZatchBottomSheetInstance = SearchWantRegisterZatchSheetViewController(viewModel: viewModel)
+    private lazy var productFrames: [ZatchSearchResultView.SearchFieldFrame] = [mainView.myZatchFrame, mainView.wantZatchFrame]
     
     init(){
         super.init(headerView: BaseHeaderView(), mainView: ZatchSearchResultView())

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
@@ -115,8 +115,8 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
             //TextField
             $0.productTextField.rx.controlEvent([.editingDidEndOnExit])
                 .bind(onNext: { [weak self] in
-                    self?.viewModel.pressTextFieldReturnKey(myProduct: self?.mainView.myZatchFrame.productTextField.text,
-                                                            wantProduct: self?.mainView.wantZatchFrame.productTextField.text)
+                    self?.viewModel.pressTextFieldReturnKey(myProduct: self?.mainView.myZatchFrame.productTextField.text ?? "",
+                                                            wantProduct: self?.mainView.wantZatchFrame.productTextField.text ?? "")
                     self?.productTextFieldDidPressReturnKey()
                 }).disposed(by: disposeBag)
             

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
@@ -35,6 +35,10 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func viewControllerWillPop() {
+        navigationController?.popToRootViewController(animated: true)
+    }
+    
     override func initialize() {
         
         super.initialize()

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
@@ -164,19 +164,18 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
     @objc private func willShowCategoryBottomSheet(recognizer: UITapGestureRecognizer){
         categoryBottomSheet.show(in: self)
         categoryBottomSheet.completion = { [weak self] categoryId in
-            if let categoryButton = recognizer.view as? ZatchSearchResultView.SearchCateogryDotButton{
-                categoryButton.isSelected = true
-                self?.setCategoryIdWithCheckProductType(of: categoryButton, categoryId: categoryId)
+            if let view = recognizer.view{
+                self?.setCategoryIdWithCheckProductType(categoryId, recognizer: view)
             }
         }
     }
     
-    private func setCategoryIdWithCheckProductType(of view: UIView, categoryId: Int) {
+    private func setCategoryIdWithCheckProductType(_ id: Int, recognizer view: UIView) {
         switch getProductType(of: view){
         case .myProduct:
-            viewModel.setMyProductCategory(id: categoryId)
+            viewModel.setMyProductCategory(id: id)
         case .wantProduct:
-            viewModel.setWantProductCategory(id: categoryId)
+            viewModel.setWantProductCategory(id: id)
         }
     }
     
@@ -202,7 +201,6 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
             case .wantProduct:      return mainView.wantZatchFrame.productTextField
             }
         }()
-        
         textField.becomeFirstResponder()
     }
     

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/ZatchSearchResultViewController.swift
@@ -101,9 +101,6 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
             }).disposed(by: disposeBag)
         
         setProductFramesRx()
-        
-        setMyZatchFrameGestureRecognizer()
-        setWantZatchFrameGestureRecognizer()
     }
     
     private func setProductFramesRx(){
@@ -121,45 +118,28 @@ class ZatchSearchResultViewController: BaseViewController<BaseHeaderView, ZatchS
                 .bind(onNext: { [weak self] in
                     self?.productTextFieldDidPressReturnKey()
                 }).disposed(by: disposeBag)
+            
+            //Product Label
+            $0.productLabel
+                .addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(willShowZatchBottomSheet(_:))))
+            
+            $0.productLabel
+                .addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(productNameTextFieldWillShow)))
+            
+            //        mainView.myZatchFrame.productLabel.rx.tapGesture()
+            //            .when(.recognized)
+            //            .bind{ [weak self] _ in
+            //                print("tap test")
+            //                self?.openMyZatchBottomSheet()
+            //            }.disposed(by: disposeBag)
+            //
+            //        mainView.myZatchFrame.productLabel.rx.longPressGesture()
+            //            .when(.recognized)
+            //            .bind{ [weak self] in
+            //                print("long press test")
+            //                self?.textFieldDidPressedLong($0)
+            //            }.disposed(by: disposeBag)
         }
-    }
-    
-    private func setMyZatchFrameGestureRecognizer(){
-        
-//        mainView.myZatchFrame.productLabel.rx.tapGesture()
-//            .when(.recognized)
-//            .bind{ [weak self] _ in
-//                print("tap test")
-//                self?.openMyZatchBottomSheet()
-//            }.disposed(by: disposeBag)
-//
-//        mainView.myZatchFrame.productLabel.rx.longPressGesture()
-//            .when(.recognized)
-//            .bind{ [weak self] in
-//                print("long press test")
-//                self?.textFieldDidPressedLong($0)
-//            }.disposed(by: disposeBag)
-        
-        mainView.myZatchFrame.productLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(willShowZatchBottomSheet(_:))))
-        mainView.myZatchFrame.productLabel.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(productNameTextFieldWillShow)))
-    }
-    
-    private func setWantZatchFrameGestureRecognizer(){
-        
-//        mainView.wantZatchFrame.productLabel.rx.longPressGesture()
-//            .when(.recognized)
-//            .bind{ [weak self] in
-//                self?.textFieldDidPressedLong($0)
-//            }.disposed(by: disposeBag)
-//
-//        mainView.wantZatchFrame.productLabel.rx.tapGesture()
-//            .when(.recognized)
-//            .bind{ [weak self] _ in
-//                self?.openWantZatchBottomSheet()
-//            }.disposed(by: disposeBag)
-        
-        mainView.wantZatchFrame.productLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(willShowZatchBottomSheet(_:))))
-        mainView.wantZatchFrame.productLabel.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(productNameTextFieldWillShow)))
     }
     
     private func getProductType(of: UIView) -> ProductType{

--- a/Zatch/Presentation/ViewModels/Search/ExchangeMyZatchSearchViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Search/ExchangeMyZatchSearchViewModel.swift
@@ -11,8 +11,20 @@ import RxCocoa
 
 class ExchangeMyZatchSearchViewModel: BaseViewModel{
     
+    private var myZatches = ["몰랑이 피규어","매일우유 250ml","콜드브루 60ml","예시가 있다면",
+                             "이렇게 들어가야","해요요요요","해요요요","해요요","해요","해","아아앙아ㅏ앙아아앙아아"]
+    private let searchManager = ZatchSearchRequestManager.shared
+    private let exchangeProduct = PublishSubject<String>()
+    private let disposeBag = DisposeBag()
+
+    private let myZatchUseCase: GetRegisterZatchUseCaseInterface
+    
+    init(myZatchUseCase: GetRegisterZatchUseCaseInterface = GetRegisterZatchUseCase()){
+        self.myZatchUseCase = myZatchUseCase
+    }
+    
     struct Input{
-        let exchangeProductName: Observable<String>
+        let exchangeProductByTextField: Observable<String>
     }
     
     struct Output{
@@ -22,16 +34,46 @@ class ExchangeMyZatchSearchViewModel: BaseViewModel{
     
     func transform(_ input: Input) -> Output {
         
-        let canMoveNext = input.exchangeProductName
-            .map{
-                !$0.isEmpty
-            }.asDriver(onErrorJustReturn: false)
+        input.exchangeProductByTextField
+            .map{ $0 }
+            .subscribe{ self.exchangeProduct.onNext($0) }
+            .disposed(by: disposeBag)
         
-        let productName = input.exchangeProductName
+        let canMoveNext = input.exchangeProductByTextField
+            .map{ !$0.isEmpty }
+            .asDriver(onErrorJustReturn: false)
+        
+        exchangeProduct
+            .subscribe{ self.searchManager.myProduct = $0 }
+            .disposed(by: disposeBag)
+        
+        let productName = exchangeProduct
             .asDriver(onErrorJustReturn: "")
-        
+           
         return Output(canMoveNext: canMoveNext,
                       exchangeProductName: productName)
     }
+}
+
+extension ExchangeMyZatchSearchViewModel{
     
+    func willSkipSelectMyZatch(){
+        searchManager.myProduct = ""
+    }
+
+    func willSelectZatch(at index: Int){
+        exchangeProduct.onNext(myZatches[index])
+    }
+    
+    func willDeselectMyZatch(){
+        exchangeProduct.onNext("")
+    }
+    
+    func getMyZatchesCount() -> Int{
+        myZatches.count
+    }
+    
+    func getMyZatch(at index: Int) -> String{
+        myZatches[index]
+    }
 }

--- a/Zatch/Presentation/ViewModels/Search/FindWantZatchSearchViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Search/FindWantZatchSearchViewModel.swift
@@ -1,0 +1,88 @@
+//
+//  FindWantZatchSearchViewModel.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/03/20.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+class FindWantZatchSearchViewModel: BaseViewModel{
+    
+    private var searchPopularKeywords = ["몰랑이","몰랑몰랑","몰랑"] //최대 3개
+    private var lookingForZatches = ["몰랑이","몰랑몰랑","몰랑"] //최대 3개
+    
+    private let searchManager = ZatchSearchRequestManager.shared
+    
+    private let wantProductName = PublishSubject<String>()
+    private let disposeBag = DisposeBag()
+    
+    private let popularKeywordUseCase: PopularKeywordUseCaseInterface
+    private let lookingForZatchUseCase: LookingForZatchUseCaseInterface
+
+    init(popularKeywordUseCase: PopularKeywordUseCaseInterface = PopularKeywordUseCase(),
+         lookingForZatchUseCase: LookingForZatchUseCaseInterface = LookingForZatchUseCase()){
+        self.popularKeywordUseCase = popularKeywordUseCase
+        self.lookingForZatchUseCase = lookingForZatchUseCase
+    }
+    
+    struct Input{
+        let productNameTextField: Observable<String>
+    }
+    
+    struct Output{
+        let searchProduct: Driver<String>
+    }
+    
+    func transform(_ input: Input) -> Output {
+        
+        input.productNameTextField
+            .subscribe{
+                self.wantProductName.onNext($0)
+            }.disposed(by: disposeBag)
+        
+        wantProductName
+            .subscribe(onNext: {
+                self.searchManager.wantProduct = $0
+            }).disposed(by: disposeBag)
+        
+        let productName = wantProductName
+            .asDriver(onErrorJustReturn: "")
+        
+        return Output(searchProduct: productName)
+    }
+    
+}
+
+extension FindWantZatchSearchViewModel{
+    
+    func getPopularKeywordsCount() -> Int{
+        searchPopularKeywords.count
+    }
+    
+    func getLookingForZatchCount() -> Int{
+        lookingForZatches.count
+    }
+    
+    func getPopularKeyword(at: Int) -> String{
+        searchPopularKeywords[at]
+    }
+    
+    func getLookingForZatch(at: Int) -> String{
+        lookingForZatches[at]
+    }
+    
+    func selectPopularKeyword(at index: Int){
+        wantProductName.onNext(searchPopularKeywords[index])
+    }
+    
+    func selectLookingForZatch(at index: Int){
+        wantProductName.onNext(lookingForZatches[index])
+    }
+    
+    func deselectCell(){
+        wantProductName.onNext("")
+    }
+}

--- a/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
@@ -1,0 +1,78 @@
+//
+//  ZatchSearchResultViewModel.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/03/20.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+class ZatchSearchResultViewModel: BaseViewModel{
+    
+    private var searchResult = [String]()
+    private var selectedMyRegisterZatchIndex: Int?
+    private var selectedLookingForZatchIndex: Int?
+    private let myProductName = BehaviorSubject<String>(value: "") //TODO: 초기값 앞에서 설정한 것으로 붙이기
+    private let wantProductName = BehaviorSubject<String>(value: "")
+    private let myProductCategory = BehaviorSubject<Int?>(value: nil)
+    private let wantProductCategory = BehaviorSubject<Int?>(value: nil)
+    
+    private let getRegisterZatchUseCase: GetRegisterZatchUseCaseInterface
+    private let getLookingForZatchUseCase: LookingForZatchUseCaseInterface
+    private let searchResultUseCase: SearchResultUseCaseInterface
+    
+    init(searchResultUseCase: SearchResultUseCaseInterface = SearchResultUseCase(),
+         getRegisterZatchUseCase: GetRegisterZatchUseCaseInterface = GetRegisterZatchUseCase(),
+         getLookingForZatchUseCase: LookingForZatchUseCaseInterface = LookingForZatchUseCase()){
+        self.searchResultUseCase = searchResultUseCase
+        self.getRegisterZatchUseCase = getRegisterZatchUseCase
+        self.getLookingForZatchUseCase = getLookingForZatchUseCase
+    }
+    
+    
+    struct Input{
+        
+    }
+    
+    struct Output{
+        let willEmptyViewHidden: Driver<Bool>
+    }
+    
+    func transform(_ input: Input) -> Output {
+        
+        let willEmptyViewHidden = Observable<String>.of("1") //TODO: searchResult 연관으로 바꾸기
+            .map{ !$0.isEmpty }
+            .asDriver(onErrorJustReturn: false)
+        
+        return Output(willEmptyViewHidden: willEmptyViewHidden)
+    }
+}
+
+extension ZatchSearchResultViewModel{
+    
+    func getSearchResultCount() -> Int{
+        searchResult.count
+    }
+    
+    func getZatch(at index: Int) -> String{
+        searchResult[index]
+    }
+    
+    func changeMyProductName(_ value: String){
+        myProductName.onNext(value)
+    }
+
+    func changeWantProductName(_ value: String){
+        wantProductName.onNext(value)
+    }
+    
+    func setMyProductCategory(id: Int){
+        myProductCategory.onNext(id)
+    }
+
+    func setWantProductCategory(id: Int){
+        wantProductCategory.onNext(id)
+    }
+}

--- a/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
@@ -17,8 +17,8 @@ class ZatchSearchResultViewModel: BaseViewModel{
     private var selectedMyRegisterZatchIndex: Int?
     private var selectedLookingForZatchIndex: Int?
     
-    private let myProductName = BehaviorSubject<String>(value: "") //TODO: 초기값 앞에서 설정한 것으로 붙이기
-    private let wantProductName = BehaviorSubject<String>(value: "")
+    private let myProductName = BehaviorSubject<String>(value: "몰랑이") //TODO: 초기값 앞에서 설정한 것으로 붙이기
+    private let wantProductName = BehaviorSubject<String>(value: "손수건")
     private let myProductCategory = BehaviorSubject<Int?>(value: nil)
     private let wantProductCategory = BehaviorSubject<Int?>(value: nil)
     
@@ -35,9 +35,7 @@ class ZatchSearchResultViewModel: BaseViewModel{
     }
     
     
-    struct Input{
-        
-    }
+    struct Input{ }
     
     struct Output{
         let isMyProductCategorySelect: Driver<Bool>
@@ -90,6 +88,11 @@ class ZatchSearchResultViewModel: BaseViewModel{
                       myProductName: myProductName,
                       wantProductName: wantProductName,
                       willEmptyViewHidden: willEmptyViewHidden)
+    }
+    
+    func pressTextFieldReturnKey(myProduct: String?, wantProduct: String?){
+        myProductName.onNext(myProduct ?? searchInitialValue)
+        wantProductName.onNext(wantProduct ?? searchInitialValue)
     }
 }
 

--- a/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
@@ -11,9 +11,12 @@ import RxCocoa
 
 class ZatchSearchResultViewModel: BaseViewModel{
     
+    private let searchInitialValue = "?"
+    
     private var searchResult = [String]()
     private var selectedMyRegisterZatchIndex: Int?
     private var selectedLookingForZatchIndex: Int?
+    
     private let myProductName = BehaviorSubject<String>(value: "") //TODO: 초기값 앞에서 설정한 것으로 붙이기
     private let wantProductName = BehaviorSubject<String>(value: "")
     private let myProductCategory = BehaviorSubject<Int?>(value: nil)
@@ -37,16 +40,56 @@ class ZatchSearchResultViewModel: BaseViewModel{
     }
     
     struct Output{
+        let isMyProductCategorySelect: Driver<Bool>
+        let isWantProductCategorySelect: Driver<Bool>
+        let myProductCategory: Driver<Int?>
+        let wantProductCategory: Driver<Int?>
+        let myProductName: Driver<String>
+        let wantProductName: Driver<String>
         let willEmptyViewHidden: Driver<Bool>
     }
     
     func transform(_ input: Input) -> Output {
         
+        let myProductCategoryConverter = myProductCategory
+            .scan((nil, nil)){ $0.1 == $1 ? (nil, nil) : ($0.1, $1) }
+            .map{ $0.1 }
+        
+        let myProductCategory = myProductCategoryConverter
+            .asDriver(onErrorJustReturn: nil)
+        
+        let isMyProductCategorySelect = myProductCategoryConverter
+            .map{ $0 == nil ? false : true }
+            .asDriver(onErrorJustReturn: false)
+        
+        let wantProductCategoryConverter = wantProductCategory
+            .scan((nil, nil)){ $0.1 == $1 ? (nil, nil) : ($0.1, $1) }
+            .map{ $0.1 }
+        
+        let wantProductCategory = wantProductCategoryConverter
+            .asDriver(onErrorJustReturn: nil)
+        
+        let isWantProductCategorySelect = wantProductCategoryConverter
+            .map{ $0 == nil ? false : true }
+            .asDriver(onErrorJustReturn: false)
+        
+        let myProductName = myProductName
+            .asDriver(onErrorJustReturn: searchInitialValue)
+        
+        let wantProductName = wantProductName
+            .asDriver(onErrorJustReturn: searchInitialValue)
+            
         let willEmptyViewHidden = Observable<String>.of("1") //TODO: searchResult 연관으로 바꾸기
             .map{ !$0.isEmpty }
             .asDriver(onErrorJustReturn: false)
         
-        return Output(willEmptyViewHidden: willEmptyViewHidden)
+        return Output(isMyProductCategorySelect: isMyProductCategorySelect,
+                      isWantProductCategorySelect: isWantProductCategorySelect,
+                      myProductCategory: myProductCategory,
+                      wantProductCategory: wantProductCategory,
+                      myProductName: myProductName,
+                      wantProductName: wantProductName,
+                      willEmptyViewHidden: willEmptyViewHidden)
     }
 }
 

--- a/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
@@ -10,12 +10,14 @@ import RxSwift
 import RxCocoa
 
 class ZatchSearchResultViewModel: BaseViewModel{
-    
+
     private let searchInitialValue = "?"
     
     private var searchResult = [String]()
-    private var selectedMyRegisterZatchIndex: Int?
-    private var selectedLookingForZatchIndex: Int?
+    private var registerZatch = ["타이머","안경닦이","호랑이 인형","램프","2022 달력", "미니 가습기","마우스 패드"]
+    private var lookingForZatch = ["타이머","안경닦이","호랑이 인형","램프","2022 달력", "미니 가습기","마우스 패드"]
+    private var selectedMyRegisterZatchIndex: Int? = nil
+    private var selectedLookingForZatchIndex: Int? = nil
     
     private let myProductName = BehaviorSubject<String>(value: "몰랑이") //TODO: 초기값 앞에서 설정한 것으로 붙이기
     private let wantProductName = BehaviorSubject<String>(value: "손수건")
@@ -104,10 +106,44 @@ extension ZatchSearchResultViewModel{
         searchResult.count
     }
     
+    func getRegisterZatchCount() -> Int{
+        registerZatch.count
+    }
+    
+    func getLookingForZatchCount() -> Int{
+        lookingForZatch.count
+    }
+    
     func getZatch(at index: Int) -> String{
         searchResult[index]
     }
     
+    func getRegisterProduct(at index: Int) -> String{
+        registerZatch[index]
+    }
+    
+    func getLookingForProduct(at index: Int) -> String{
+        lookingForZatch[index]
+    }
+    
+    func changeMyProductByRegisterZatch(at index: Int){
+        changeRegisterZatch(index: index)
+        changeMyProductName(registerZatch[index])
+    }
+    
+    private func changeRegisterZatch(index: Int?){
+        selectedMyRegisterZatchIndex = index
+    }
+    
+    func changeWantProductByLookingForZatch(at index: Int){
+        changeLookingForZatch(index: index)
+        changeWantProductName(lookingForZatch[index])
+    }
+    
+    private func changeLookingForZatch(index: Int?){
+        selectedLookingForZatchIndex = index
+    }
+
     func changeMyProductName(_ value: String){
         myProductName.onNext(value)
     }
@@ -122,5 +158,13 @@ extension ZatchSearchResultViewModel{
 
     func setWantProductCategory(id: Int){
         wantProductCategory.onNext(id)
+    }
+    
+    func isRegisterZatchSelected(at index: Int) -> Bool{
+        selectedMyRegisterZatchIndex == index
+    }
+    
+    func isLookingForZatchSelected(at index: Int) -> Bool{
+        selectedLookingForZatchIndex == index
     }
 }

--- a/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
@@ -91,6 +91,8 @@ class ZatchSearchResultViewModel: BaseViewModel{
     }
     
     func pressTextFieldReturnKey(myProduct: String?, wantProduct: String?){
+        selectedMyRegisterZatchIndex = nil
+        selectedLookingForZatchIndex = nil
         myProductName.onNext(myProduct ?? searchInitialValue)
         wantProductName.onNext(wantProduct ?? searchInitialValue)
     }

--- a/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Search/ZatchSearchResultViewModel.swift
@@ -92,11 +92,15 @@ class ZatchSearchResultViewModel: BaseViewModel{
                       willEmptyViewHidden: willEmptyViewHidden)
     }
     
-    func pressTextFieldReturnKey(myProduct: String?, wantProduct: String?){
-        selectedMyRegisterZatchIndex = nil
-        selectedLookingForZatchIndex = nil
-        myProductName.onNext(myProduct ?? searchInitialValue)
-        wantProductName.onNext(wantProduct ?? searchInitialValue)
+    func pressTextFieldReturnKey(myProduct: String, wantProduct: String){
+        changeRegisterZatch(index: nil)
+        changeLookingForZatch(index: nil)
+        if(!myProduct.isEmpty){
+            changeMyProductName(myProduct)
+        }
+        if(!wantProduct.isEmpty){
+            changeWantProductName(wantProduct)
+        }
     }
 }
 

--- a/Zatch/Presentation/Views/SearchView/Sheet/SearchMyRegisterZatchSheetViewController.swift
+++ b/Zatch/Presentation/Views/SearchView/Sheet/SearchMyRegisterZatchSheetViewController.swift
@@ -10,8 +10,8 @@ import SnapKit
 
 class SearchMyRegisterZatchSheetViewController: SearchTagSheetViewController{
     
-    init(){
-        super.init(type: .searchMyTag)
+    init(viewModel: ZatchSearchResultViewModel){
+        super.init(viewModel: viewModel, type: .searchMyTag)
     }
     
     required init?(coder: NSCoder) {

--- a/Zatch/Presentation/Views/SearchView/Sheet/SearchMyRegisterZatchSheetViewController.swift
+++ b/Zatch/Presentation/Views/SearchView/Sheet/SearchMyRegisterZatchSheetViewController.swift
@@ -23,18 +23,25 @@ class SearchMyRegisterZatchSheetViewController: SearchTagSheetViewController{
         collectionView.register(cellType: SearchMyZatchByRegisterCollectionViewCell.self)
     }
     
-    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: SearchMyZatchByRegisterCollectionViewCell.self).then{
-            $0.setTitle(title: tagData[indexPath.row])
-        }
-        if(indexPath.row == currentTag){
-            cell.isSelectedState = true
-        }
-        return cell
+    //MARK: - CollectionViewDelegate
+    
+    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        viewModel.getRegisterZatchCount()
     }
     
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        completion(indexPath.row)
-        self.dismiss(animated: true)
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        collectionView.dequeueReusableCell(for: indexPath, cellType: SearchMyZatchByRegisterCollectionViewCell.self).then{
+            $0.setTitle(title: viewModel.getRegisterProduct(at: indexPath.row))
+            $0.isSelectedState = viewModel.isRegisterZatchSelected(at: indexPath.row) ? true : false
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        SearchMyZatchByRegisterCollectionViewCell.getEstimatedSize(title: viewModel.getRegisterProduct(at: indexPath.row))
+    }
+    
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        viewModel.changeMyProductByRegisterZatch(at: indexPath.row)
+        super.collectionView(collectionView, didSelectItemAt: indexPath)
     }
 }

--- a/Zatch/Presentation/Views/SearchView/Sheet/SearchTagSheetViewController.swift
+++ b/Zatch/Presentation/Views/SearchView/Sheet/SearchTagSheetViewController.swift
@@ -37,33 +37,31 @@ class SearchTagSheetViewController: BaseBottomSheetViewController<Int>{
     
     override func layout() {
         super.layout()
-        self.view.addSubview(collectionView)
+        view.addSubview(collectionView)
         collectionView.snp.makeConstraints{
-            $0.top.equalTo(self.titleLabel.snp.bottom).offset(20)
-            $0.leading.equalToSuperview().offset(35)
-            $0.trailing.equalToSuperview().offset(-35)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(35)
             $0.bottom.equalToSuperview().offset(-30)
         }
     }
     override func initialize() {
         super.initialize()
-        collectionView.dataSource = self
-        collectionView.delegate = self
+        collectionView.initializeDelegate(self)
     }
 }
 
 extension SearchTagSheetViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout{
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return self.tagData.count
+        return tagData.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        return BaseCollectionViewCell()
+        BaseCollectionViewCell()
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return SearchWantZatchByRegisterCollectionViewCell.getEstimatedSize(title: tagData[indexPath.row])
+        SearchWantZatchByRegisterCollectionViewCell.getEstimatedSize(title: tagData[indexPath.row])
     }
 
 }

--- a/Zatch/Presentation/Views/SearchView/Sheet/SearchTagSheetViewController.swift
+++ b/Zatch/Presentation/Views/SearchView/Sheet/SearchTagSheetViewController.swift
@@ -23,7 +23,18 @@ class SearchTagSheetViewController: BaseBottomSheetViewController<Int>{
         }
         $0.collectionViewLayout = flexLayout
     }
-
+    
+    private let viewModel: ZatchSearchResultViewModel
+    
+    init(viewModel: ZatchSearchResultViewModel, type: BottomSheet){
+        self.viewModel = viewModel
+        super.init(type: type)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func layout() {
         super.layout()
         self.view.addSubview(collectionView)

--- a/Zatch/Presentation/Views/SearchView/Sheet/SearchTagSheetViewController.swift
+++ b/Zatch/Presentation/Views/SearchView/Sheet/SearchTagSheetViewController.swift
@@ -6,15 +6,11 @@
 //
 
 import UIKit
+import RxSwift
 
 class SearchTagSheetViewController: BaseBottomSheetViewController<Int>{
     
     //MARK: - Properties
-    
-    var tagData = ["타이머","안경닦이","호랑이 인형","램프","2022 달력", "미니 가습기","마우스 패드"]
-    var currentTag: Int?
-    
-    //MARK: - UI
     
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then{
         let flexLayout = CenterAlignCollectionViewFlowLayout().then{
@@ -24,7 +20,7 @@ class SearchTagSheetViewController: BaseBottomSheetViewController<Int>{
         $0.collectionViewLayout = flexLayout
     }
     
-    private let viewModel: ZatchSearchResultViewModel
+    let viewModel: ZatchSearchResultViewModel
     
     init(viewModel: ZatchSearchResultViewModel, type: BottomSheet){
         self.viewModel = viewModel
@@ -33,6 +29,12 @@ class SearchTagSheetViewController: BaseBottomSheetViewController<Int>{
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    //MARK: - Override
+    
+    override func viewWillAppear(_ animated: Bool) {
+        collectionView.reloadData()
     }
     
     override func layout() {
@@ -44,6 +46,7 @@ class SearchTagSheetViewController: BaseBottomSheetViewController<Int>{
             $0.bottom.equalToSuperview().offset(-30)
         }
     }
+    
     override func initialize() {
         super.initialize()
         collectionView.initializeDelegate(self)
@@ -53,15 +56,15 @@ class SearchTagSheetViewController: BaseBottomSheetViewController<Int>{
 extension SearchTagSheetViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout{
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return tagData.count
+        0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         BaseCollectionViewCell()
     }
     
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        SearchWantZatchByRegisterCollectionViewCell.getEstimatedSize(title: tagData[indexPath.row])
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        dismiss(animated: true)
     }
 
 }

--- a/Zatch/Presentation/Views/SearchView/Sheet/SearchWantRegisterZatchSheetViewController.swift
+++ b/Zatch/Presentation/Views/SearchView/Sheet/SearchWantRegisterZatchSheetViewController.swift
@@ -9,8 +9,8 @@ import UIKit
 
 class SearchWantRegisterZatchSheetViewController: SearchTagSheetViewController{
     
-    init(){
-        super.init(type: .searchWantTag)
+    init(viewModel: ZatchSearchResultViewModel){
+        super.init(viewModel: viewModel, type: .searchWantTag)
     }
     
     required init?(coder: NSCoder) {

--- a/Zatch/Presentation/Views/SearchView/Sheet/SearchWantRegisterZatchSheetViewController.swift
+++ b/Zatch/Presentation/Views/SearchView/Sheet/SearchWantRegisterZatchSheetViewController.swift
@@ -22,19 +22,31 @@ class SearchWantRegisterZatchSheetViewController: SearchTagSheetViewController{
         collectionView.register(cellType: SearchWantZatchByRegisterCollectionViewCell.self)
     }
     
-    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: SearchWantZatchByRegisterCollectionViewCell.self).then{
-            $0.setTitle(title: tagData[indexPath.row])
-        }
-        if(indexPath.row == currentTag){
-            cell.isSelectedState = true
-        }
-        return cell
+    //MARK: - CollectionViewDelegate
+    
+    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        viewModel.getLookingForZatchCount()
     }
     
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        completion(indexPath.row)
-        self.dismiss(animated: true)
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        //객체 생성될 때 한번만 로드
+        return collectionView.dequeueReusableCell(for: indexPath, cellType: SearchWantZatchByRegisterCollectionViewCell.self).then{
+            $0.setTitle(title: viewModel.getLookingForProduct(at: indexPath.row))
+            $0.isSelectedState = viewModel.isLookingForZatchSelected(at: indexPath.row) ? true : false
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        SearchWantZatchByRegisterCollectionViewCell.getEstimatedSize(title: viewModel.getLookingForProduct(at: indexPath.row))
+    }
+    
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        viewModel.changeWantProductByLookingForZatch(at: indexPath.row)
+        super.collectionView(collectionView, didSelectItemAt: indexPath)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        collectionView.dequeueReusableCell(for: indexPath, cellType: SearchWantZatchByRegisterCollectionViewCell.self).isSelectedState = false
     }
 
 }

--- a/Zatch/Presentation/Views/SearchView/Zatch/FindWantZatchSearchView.swift
+++ b/Zatch/Presentation/Views/SearchView/Zatch/FindWantZatchSearchView.swift
@@ -30,7 +30,7 @@ class FindWantZatchSearchView: BaseView {
         $0.font = UIFont.pretendard(size: 15, family: .Bold)
     }
     
-    let firstCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then{
+    let popularKeywordCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then{
         
         let flexLayout = UICollectionViewFlowLayout()
         flexLayout.scrollDirection = .horizontal
@@ -45,7 +45,7 @@ class FindWantZatchSearchView: BaseView {
         $0.textColor = .black85
         $0.setTypoStyleWithSingleLine(typoStyle: .bold18)
     }
-    let secondCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then{
+    let lookingForCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then{
         
         let flexLayout = UICollectionViewFlowLayout()
         flexLayout.scrollDirection = .horizontal
@@ -61,9 +61,9 @@ class FindWantZatchSearchView: BaseView {
         self.addSubview(titleView)
         self.addSubview(searchFrame)
         self.addSubview(subTitle1)
-        self.addSubview(firstCollectionView)
+        self.addSubview(popularKeywordCollectionView)
         self.addSubview(subTitle2)
-        self.addSubview(secondCollectionView)
+        self.addSubview(lookingForCollectionView)
         self.addSubview(nextButton)
         
         searchFrame.addSubview(myProductNameLabel)
@@ -103,7 +103,7 @@ class FindWantZatchSearchView: BaseView {
             $0.leading.equalToSuperview().offset(24)
         }
         
-        firstCollectionView.snp.makeConstraints{
+        popularKeywordCollectionView.snp.makeConstraints{
             $0.top.equalTo(subTitle1.snp.bottom).offset(12)
             $0.leading.equalToSuperview().offset(16)
             $0.trailing.equalToSuperview().offset(-16)
@@ -111,11 +111,11 @@ class FindWantZatchSearchView: BaseView {
         }
         
         subTitle2.snp.makeConstraints{
-            $0.top.equalTo(firstCollectionView.snp.bottom).offset(28)
+            $0.top.equalTo(popularKeywordCollectionView.snp.bottom).offset(28)
             $0.left.equalToSuperview().offset(24)
         }
         
-        secondCollectionView.snp.makeConstraints{
+        lookingForCollectionView.snp.makeConstraints{
             $0.top.equalTo(subTitle2.snp.bottom).offset(12)
             $0.leading.equalToSuperview().offset(16)
             $0.trailing.equalToSuperview().offset(-16)

--- a/Zatch/Presentation/Views/SearchView/Zatch/ZatchSearchResultView.swift
+++ b/Zatch/Presentation/Views/SearchView/Zatch/ZatchSearchResultView.swift
@@ -33,16 +33,16 @@ class ZatchSearchResultView: BaseView {
     
     override func hierarchy(){
 
-        self.addSubview(topView)
-        self.addSubview(separateLine)
-        self.addSubview(separateSection)
-        self.addSubview(tableView)
+        addSubview(topView)
+        addSubview(separateLine)
+        addSubview(separateSection)
+        addSubview(tableView)
         
-        self.topView.addSubview(exchangeImage)
-        self.topView.addSubview(myZatchFrame)
-        self.topView.addSubview(wantZatchFrame)
-        self.topView.addSubview(townFrame)
-        self.topView.addSubview(searchFrame)
+        topView.addSubview(exchangeImage)
+        topView.addSubview(myZatchFrame)
+        topView.addSubview(wantZatchFrame)
+        topView.addSubview(townFrame)
+        topView.addSubview(searchFrame)
     }
     
     override func layout(){
@@ -159,6 +159,7 @@ extension ZatchSearchResultView{
             $0.textColor = .black85
             $0.font = UIFont.pretendard(size: 20, family: .Bold)
             $0.addPadding()
+            $0.setPlaceholderColor(.black10)
             $0.tintColor = .black10
             $0.returnKeyType = .done
             


### PR DESCRIPTION
## What is this PR? 🔍

재치 검색 ViewModel 역할 확장 및 Clean Architecture 적용

## Key Changes 🔑

### 1. SearchRepository 추가
+ 검색에서 필요한 UseCase 등 API 파일 세팅

### 2. ViewModel 적용
+ 이전에는 내가 교환할 재치 선택에서만 ViewModel 활용했었음
+ 이번에 리팩토링을 진행하면서 내가 찾는 재치, 검색 결과에도 ViewModel 적용 완료
+ ViewController에서 진행하던 비즈니스 로직을 모두 ViewModel에서 담당하도록 리팩토링해 ViewController의 역할이 많이 줄어들었음

### 3. ViewController 등 모듈화 진행
+ 헬퍼 함수 추가하고 각 메서드의 역할을 줄이는 식으로 모듈화를 진행했으며, 이전보다 역할 구분도 확실해지고 코드 가독성도 좋아짐

## Related Issues ⛱
close #206
