### PR TITLE
Refactor/#206: SearchTagSheet 추상 메서드 추가 및 하위 클래스 구현 통한 Cell size 설정

### DIFF
--- a/Zatch/Presentation/Views/SearchView/Sheet/SearchMyRegisterZatchSheetViewController.swift
+++ b/Zatch/Presentation/Views/SearchView/Sheet/SearchMyRegisterZatchSheetViewController.swift
@@ -36,12 +36,12 @@ class SearchMyRegisterZatchSheetViewController: SearchTagSheetViewController{
         }
     }
     
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        SearchMyZatchByRegisterCollectionViewCell.getEstimatedSize(title: viewModel.getRegisterProduct(at: indexPath.row))
-    }
-    
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         viewModel.changeMyProductByRegisterZatch(at: indexPath.row)
         super.collectionView(collectionView, didSelectItemAt: indexPath)
+    }
+    
+    override func getCellTitle(index: Int) -> String {
+        viewModel.getRegisterProduct(at: index)
     }
 }

--- a/Zatch/Presentation/Views/SearchView/Sheet/SearchTagSheetViewController.swift
+++ b/Zatch/Presentation/Views/SearchView/Sheet/SearchTagSheetViewController.swift
@@ -66,5 +66,13 @@ extension SearchTagSheetViewController: UICollectionViewDelegate, UICollectionVi
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         dismiss(animated: true)
     }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        SearchWantZatchByRegisterCollectionViewCell.getEstimatedSize(title: getCellTitle(index: indexPath.row))
+    }
+    
+    @objc func getCellTitle(index: Int) -> String {
+        ""
+    }
 
 }

--- a/Zatch/Presentation/Views/SearchView/Sheet/SearchWantRegisterZatchSheetViewController.swift
+++ b/Zatch/Presentation/Views/SearchView/Sheet/SearchWantRegisterZatchSheetViewController.swift
@@ -36,10 +36,6 @@ class SearchWantRegisterZatchSheetViewController: SearchTagSheetViewController{
         }
     }
     
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        SearchWantZatchByRegisterCollectionViewCell.getEstimatedSize(title: viewModel.getLookingForProduct(at: indexPath.row))
-    }
-    
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         viewModel.changeWantProductByLookingForZatch(at: indexPath.row)
         super.collectionView(collectionView, didSelectItemAt: indexPath)
@@ -47,6 +43,10 @@ class SearchWantRegisterZatchSheetViewController: SearchTagSheetViewController{
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         collectionView.dequeueReusableCell(for: indexPath, cellType: SearchWantZatchByRegisterCollectionViewCell.self).isSelectedState = false
+    }
+    
+    override func getCellTitle(index: Int) -> String {
+        viewModel.getLookingForProduct(at: index)
     }
 
 }


### PR DESCRIPTION
## What is this PR? 🔍

SearchTagSheet 추상 메서드 추가 및 하위 클래스 구현 통한 Cell size 설정

## Key Changes 🔑

+ 내가 등록한 재치 / 내가 찾는 재치 VC에서 title을 받아오는 ViewModel의 메서드/프로퍼티가 달라 각각 Cell size 메서드를 구현해줬었음
+ 코드가 동일해 중복 문제 발생
+ SearchTagSheetVC에서 cellSize 지정 collectionView 메서드를 지정하고, 헬퍼 메서드로 title을 넘겨줄 수 있도록 함

## Related Issues ⛱
#206
