### PR TITLE
Refactor/#218: 재치 등록 ViewModel 활용 리팩토링 일부 완료

### DIFF
--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -263,6 +263,8 @@
 		57FFEDC728DD2F1B0041719B /* CheckExchangeRegisterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFEDC628DD2F1B0041719B /* CheckExchangeRegisterViewController.swift */; };
 		6AF93CFE86982B0FFAF29206 /* Pods_Zatch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99A9FAD0C12F2252FE5C8E69 /* Pods_Zatch.framework */; };
 		D1533A389FEC70B77AD110F6 /* Pods_ZatchTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2828C8E20374F7AEAB414182 /* Pods_ZatchTests.framework */; };
+		EE0AD54529E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54429E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift */; };
+		EE0AD54729E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54629E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift */; };
 		EE0D8E4B29B73CE000D96050 /* NoticeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D8E4A29B73CE000D96050 /* NoticeDetailView.swift */; };
 		EE0D8E4D29B7561200D96050 /* TableOnlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D8E4C29B7561200D96050 /* TableOnlyView.swift */; };
 		EE27C54529C826E000285CC5 /* SearchRepositotyInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54429C826E000285CC5 /* SearchRepositotyInterface.swift */; };
@@ -273,6 +275,7 @@
 		EE27C55029C892D700285CC5 /* SearchResultUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54F29C892D700285CC5 /* SearchResultUseCase.swift */; };
 		EE2801BC29C6F07E003595A5 /* GetRegisterZatchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2801BB29C6F07E003595A5 /* GetRegisterZatchUseCase.swift */; };
 		EE2801BE29C6F0AD003595A5 /* LookingForZatchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2801BD29C6F0AD003595A5 /* LookingForZatchUseCase.swift */; };
+		EE2AE71229E43311007046C8 /* RegisterZatchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2AE71129E43311007046C8 /* RegisterZatchUseCase.swift */; };
 		EE2BC348298295C3002B5C60 /* EtcButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BC347298295C3002B5C60 /* EtcButton.swift */; };
 		EE2BC34A29829A32002B5C60 /* CenterNavigationHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BC34929829A32002B5C60 /* CenterNavigationHeaderView.swift */; };
 		EE2BC34D2982B067002B5C60 /* EtcButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BC34C2982B067002B5C60 /* EtcButtonHeaderView.swift */; };
@@ -661,6 +664,8 @@
 		6E2CF233E53955D92629E42D /* Pods-Zatch-ZatchUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zatch-ZatchUITests.release.xcconfig"; path = "Target Support Files/Pods-Zatch-ZatchUITests/Pods-Zatch-ZatchUITests.release.xcconfig"; sourceTree = "<group>"; };
 		99A9FAD0C12F2252FE5C8E69 /* Pods_Zatch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Zatch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E93BEB6442FCA2A68AFE12C0 /* Pods-Zatch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zatch.debug.xcconfig"; path = "Target Support Files/Pods-Zatch/Pods-Zatch.debug.xcconfig"; sourceTree = "<group>"; };
+		EE0AD54429E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRegisterTestViewModel.swift; sourceTree = "<group>"; };
+		EE0AD54629E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProductInfoTestViewController.swift; sourceTree = "<group>"; };
 		EE0D8E4A29B73CE000D96050 /* NoticeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeDetailView.swift; sourceTree = "<group>"; };
 		EE0D8E4C29B7561200D96050 /* TableOnlyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableOnlyView.swift; sourceTree = "<group>"; };
 		EE27C54429C826E000285CC5 /* SearchRepositotyInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositotyInterface.swift; sourceTree = "<group>"; };
@@ -671,6 +676,7 @@
 		EE27C54F29C892D700285CC5 /* SearchResultUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultUseCase.swift; sourceTree = "<group>"; };
 		EE2801BB29C6F07E003595A5 /* GetRegisterZatchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRegisterZatchUseCase.swift; sourceTree = "<group>"; };
 		EE2801BD29C6F0AD003595A5 /* LookingForZatchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookingForZatchUseCase.swift; sourceTree = "<group>"; };
+		EE2AE71129E43311007046C8 /* RegisterZatchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterZatchUseCase.swift; sourceTree = "<group>"; };
 		EE2BC347298295C3002B5C60 /* EtcButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EtcButton.swift; sourceTree = "<group>"; };
 		EE2BC34929829A32002B5C60 /* CenterNavigationHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterNavigationHeaderView.swift; sourceTree = "<group>"; };
 		EE2BC34C2982B067002B5C60 /* EtcButtonHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EtcButtonHeaderView.swift; sourceTree = "<group>"; };
@@ -1094,6 +1100,7 @@
 		23C9031428C5CE6400FB6D3D /* Register */ = {
 			isa = PBXGroup;
 			children = (
+				EE0AD54629E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift */,
 				57600C072963073900A7F27B /* Zatch */,
 			);
 			path = Register;
@@ -2076,6 +2083,7 @@
 			isa = PBXGroup;
 			children = (
 				EE642C5C298FAE2C00E15869 /* ZatchRegisterFirstViewModel.swift */,
+				EE0AD54429E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift */,
 			);
 			path = Register;
 			sourceTree = "<group>";
@@ -2149,6 +2157,7 @@
 		EE7B76D029C5F61C00942798 /* Zatch */ = {
 			isa = PBXGroup;
 			children = (
+				EE2AE71129E43311007046C8 /* RegisterZatchUseCase.swift */,
 				EE7B76D129C5F61C00942798 /* HeartZatchUseCase.swift */,
 				EE7B76D229C5F61C00942798 /* AroundZatchUseCase.swift */,
 				EE7B76D329C5F61C00942798 /* PopularZatchUseCase.swift */,
@@ -2591,6 +2600,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE0AD54529E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift in Sources */,
 				EE813FFD29C585400091F16E /* UserRepository.swift in Sources */,
 				EE541C1F29B44F1200DD0F20 /* StatusResponseModel.swift in Sources */,
 				57B32C34291FB58F0018C0CB /* Image.swift in Sources */,
@@ -2599,6 +2609,7 @@
 				EE33D21E2993E1120020866E /* ZatchComponent.swift in Sources */,
 				5767752C281CDA4B000BC7CD /* ExchangeMyZatchSearchViewController.swift in Sources */,
 				5767D77528682D120075DB28 /* DetailImageTableViewCell.swift in Sources */,
+				EE2AE71229E43311007046C8 /* RegisterZatchUseCase.swift in Sources */,
 				EE73C51C299600230000F8AC /* RegisterCellDelegate.swift in Sources */,
 				571C0C7528AB224E002293B6 /* ChattingListTableViewCell.swift in Sources */,
 				57EBCE4028A8906000212D20 /* CancelAlertViewController.swift in Sources */,
@@ -2747,6 +2758,7 @@
 				EE7AFF5729D16652007872B9 /* MeetingLocationRegisterMapViewController.swift in Sources */,
 				574EC1ED282E62A000E3CE4B /* RegisterCategorySelectTableViewCell.swift in Sources */,
 				57FFEDC528DD2F0D0041719B /* CheckShareRegisterViewController.swift in Sources */,
+				EE0AD54729E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift in Sources */,
 				576341AB28D29D120067D2C5 /* BlockUserTableViewCell.swift in Sources */,
 				EEE6D1652997BF830004FC7B /* ZatchButton.swift in Sources */,
 				57D6D79F28CDC02600F805B7 /* ModifyMeetingSheetViewController.swift in Sources */,

--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		EE0AD54529E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54429E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift */; };
 		EE0AD54729E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54629E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift */; };
 		EE0AD54929E542A400C1CDA1 /* Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54829E542A400C1CDA1 /* Register.swift */; };
+		EE0AD54B29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54A29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift */; };
 		EE0D8E4B29B73CE000D96050 /* NoticeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D8E4A29B73CE000D96050 /* NoticeDetailView.swift */; };
 		EE0D8E4D29B7561200D96050 /* TableOnlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D8E4C29B7561200D96050 /* TableOnlyView.swift */; };
 		EE27C54529C826E000285CC5 /* SearchRepositotyInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54429C826E000285CC5 /* SearchRepositotyInterface.swift */; };
@@ -668,6 +669,7 @@
 		EE0AD54429E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRegisterTestViewModel.swift; sourceTree = "<group>"; };
 		EE0AD54629E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProductInfoTestViewController.swift; sourceTree = "<group>"; };
 		EE0AD54829E542A400C1CDA1 /* Register.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Register.swift; sourceTree = "<group>"; };
+		EE0AD54A29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZatchRegisterDelegate.swift; sourceTree = "<group>"; };
 		EE0D8E4A29B73CE000D96050 /* NoticeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeDetailView.swift; sourceTree = "<group>"; };
 		EE0D8E4C29B7561200D96050 /* TableOnlyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableOnlyView.swift; sourceTree = "<group>"; };
 		EE27C54429C826E000285CC5 /* SearchRepositotyInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositotyInterface.swift; sourceTree = "<group>"; };
@@ -2078,6 +2080,7 @@
 			children = (
 				EE642C59298FA9A000E15869 /* ZatchRegisterRequestManager.swift */,
 				EE0AD54829E542A400C1CDA1 /* Register.swift */,
+				EE0AD54A29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift */,
 			);
 			path = Register;
 			sourceTree = "<group>";
@@ -2868,6 +2871,7 @@
 				23B051BF28E20622005D08EA /* QnAViewController.swift in Sources */,
 				EE7B76D929C5F61C00942798 /* GetMyTownUseCase.swift in Sources */,
 				57D6D79528CDBC3A00F805B7 /* MeetingSheetView.swift in Sources */,
+				EE0AD54B29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift in Sources */,
 				57D6D7A328CDC32200F805B7 /* PlaceSearchRepsonseModel.swift in Sources */,
 				57F68BAA29652ED300DB1471 /* DetailEtcBottomSheetView.swift in Sources */,
 				EE7B76C129C5E36D00942798 /* ZatchRepositoryInterface.swift in Sources */,

--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 		D1533A389FEC70B77AD110F6 /* Pods_ZatchTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2828C8E20374F7AEAB414182 /* Pods_ZatchTests.framework */; };
 		EE0AD54529E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54429E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift */; };
 		EE0AD54729E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54629E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift */; };
+		EE0AD54929E542A400C1CDA1 /* Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54829E542A400C1CDA1 /* Register.swift */; };
 		EE0D8E4B29B73CE000D96050 /* NoticeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D8E4A29B73CE000D96050 /* NoticeDetailView.swift */; };
 		EE0D8E4D29B7561200D96050 /* TableOnlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D8E4C29B7561200D96050 /* TableOnlyView.swift */; };
 		EE27C54529C826E000285CC5 /* SearchRepositotyInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54429C826E000285CC5 /* SearchRepositotyInterface.swift */; };
@@ -666,6 +667,7 @@
 		E93BEB6442FCA2A68AFE12C0 /* Pods-Zatch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zatch.debug.xcconfig"; path = "Target Support Files/Pods-Zatch/Pods-Zatch.debug.xcconfig"; sourceTree = "<group>"; };
 		EE0AD54429E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRegisterTestViewModel.swift; sourceTree = "<group>"; };
 		EE0AD54629E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProductInfoTestViewController.swift; sourceTree = "<group>"; };
+		EE0AD54829E542A400C1CDA1 /* Register.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Register.swift; sourceTree = "<group>"; };
 		EE0D8E4A29B73CE000D96050 /* NoticeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeDetailView.swift; sourceTree = "<group>"; };
 		EE0D8E4C29B7561200D96050 /* TableOnlyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableOnlyView.swift; sourceTree = "<group>"; };
 		EE27C54429C826E000285CC5 /* SearchRepositotyInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositotyInterface.swift; sourceTree = "<group>"; };
@@ -2075,6 +2077,7 @@
 			isa = PBXGroup;
 			children = (
 				EE642C59298FA9A000E15869 /* ZatchRegisterRequestManager.swift */,
+				EE0AD54829E542A400C1CDA1 /* Register.swift */,
 			);
 			path = Register;
 			sourceTree = "<group>";
@@ -2630,6 +2633,7 @@
 				EE541C1B29B44E9100DD0F20 /* MoyaLoggerPlugin.swift in Sources */,
 				5795770428BB1AB400237A12 /* MemberDeclarationSheetViewController.swift in Sources */,
 				5722460828BE0D0D009B7C78 /* RightChattingImageTableViewCell.swift in Sources */,
+				EE0AD54929E542A400C1CDA1 /* Register.swift in Sources */,
 				EE541C1D29B44EE400DD0F20 /* BaseResponseModel.swift in Sources */,
 				57468A9B28A1098300056691 /* UITextField.swift in Sources */,
 				57A28B3D28CED93700263079 /* MapTownViewController.swift in Sources */,

--- a/Zatch/Data/Repository/ZatchRepository.swift
+++ b/Zatch/Data/Repository/ZatchRepository.swift
@@ -8,6 +8,11 @@
 import Foundation
 
 final class ZatchRepository: ZatchRepositoryInterface {
+    
+    func registerZatch(){
+        
+    }
+    
     func getRegisterZatch() {
         
     }
@@ -19,9 +24,11 @@ final class ZatchRepository: ZatchRepositoryInterface {
     func getPopularZatch(){
         
     }
+    
     func getAroundZatch(){
         
     }
+    
     func fetchHeartState(){
         
     }

--- a/Zatch/Domain/RepositoryInterface/ZatchRepositoryInterface.swift
+++ b/Zatch/Domain/RepositoryInterface/ZatchRepositoryInterface.swift
@@ -8,9 +8,11 @@
 import Foundation
 
 protocol ZatchRepositoryInterface {
+    func registerZatch()
     func getPopularZatch()
     func getAroundZatch()
     func fetchHeartState()
     func getRegisterZatch()
     func getLookingForZatch()
 }
+

--- a/Zatch/Domain/UseCase/Zatch/RegisterZatchUseCase.swift
+++ b/Zatch/Domain/UseCase/Zatch/RegisterZatchUseCase.swift
@@ -1,0 +1,46 @@
+//
+//  RegisterZatchUseCase.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/04/10.
+//
+
+import Foundation
+
+struct RegisterZatchRequestModel {
+    
+    struct PriorityProduct{
+        let priority: Int
+        let productName: String
+        let categoryId: Int
+    }
+    
+    let anyZatch: Int
+    let categoryId: Int
+    let content: String
+    let expirationDate: String
+    let isFree: Bool
+    let isOpened: Int
+    let itemName: String
+    let purchaseDate: String
+    let quantity: String
+    let priorites: [PriorityProduct] //임시 설정
+    let userId: Int
+}
+
+protocol RegisterUseCaseInterface {
+    func execute(requestValue: RegisterZatchRequestModel) async throws
+}
+
+final class RegisterUseCase: RegisterUseCaseInterface {
+
+    private let zatchRepository: ZatchRepositoryInterface
+
+    init(zatchRepository: ZatchRepositoryInterface = ZatchRepository()) {
+        self.zatchRepository = zatchRepository
+    }
+
+    func execute(requestValue: RegisterZatchRequestModel) async throws {
+        return try await zatchRepository.registerZatch()
+    }
+}

--- a/Zatch/Global/Source/Alert/Picker/DatePickerAlertViewController.swift
+++ b/Zatch/Global/Source/Alert/Picker/DatePickerAlertViewController.swift
@@ -20,6 +20,8 @@ class DatePickerAlertViewController: PickerAlertViewController {
     var year: Int!
     var dateArray : [Int] = []
     
+    var completionTest: ((String) -> ())!
+    
     //MARK: - UI
     
     let datePicker = UIPickerView()
@@ -81,8 +83,12 @@ class DatePickerAlertViewController: PickerAlertViewController {
     }
     
     override func okBtnDidClicked() {
-        self.pickerHandler!(dateArray)
-        self.dismiss(animated: false, completion: nil)
+        completionTest(dateString)
+        dismiss(animated: false, completion: nil)
+    }
+    
+    private var dateString: String{
+        "\(dateArray[0])-\(dateArray[1] + 1)-\(dateArray[2] + 1)"
     }
 
 }

--- a/Zatch/Global/Source/Alert/Picker/DatePickerAlertViewController.swift
+++ b/Zatch/Global/Source/Alert/Picker/DatePickerAlertViewController.swift
@@ -25,7 +25,16 @@ class DatePickerAlertViewController: PickerAlertViewController {
     //MARK: - UI
     
     let datePicker = UIPickerView()
-
+    
+    init(about: Register.ProductDate){
+        super.init(nibName: nil, bundle: nil)
+        titleLabel.text = about.rawValue
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     //MARK: - Lifecycle
     
     override func viewDidLoad() {

--- a/Zatch/Global/Source/Alert/Picker/DatePickerAlertViewController.swift
+++ b/Zatch/Global/Source/Alert/Picker/DatePickerAlertViewController.swift
@@ -20,7 +20,7 @@ class DatePickerAlertViewController: PickerAlertViewController {
     var year: Int!
     var dateArray : [Int] = []
     
-    var completionTest: ((String) -> ())!
+    var completionTest: ((Register.DateString) -> ())!
     
     //MARK: - UI
     
@@ -83,12 +83,8 @@ class DatePickerAlertViewController: PickerAlertViewController {
     }
     
     override func okBtnDidClicked() {
-        completionTest(dateString)
+        completionTest(("\(dateArray[0])", "\(dateArray[1] + 1)", "\(dateArray[2] + 1)"))
         dismiss(animated: false, completion: nil)
-    }
-    
-    private var dateString: String{
-        "\(dateArray[0])-\(dateArray[1] + 1)-\(dateArray[2] + 1)"
     }
 
 }

--- a/Zatch/Global/Source/Base/ViewController/BaseViewController.swift
+++ b/Zatch/Global/Source/Base/ViewController/BaseViewController.swift
@@ -31,6 +31,11 @@ class BaseViewController<T: BaseHeaderView,
     final let disposeBag = DisposeBag()
     
     //MARK: - LifeCycle
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        bindAfterViewAppear()
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -67,6 +72,8 @@ class BaseViewController<T: BaseHeaderView,
     }
     
     func bind() { }
+    
+    func bindAfterViewAppear(){ }
     
     //MARK: - Action
     

--- a/Zatch/Global/Source/Base/ViewController/BaseViewController.swift
+++ b/Zatch/Global/Source/Base/ViewController/BaseViewController.swift
@@ -16,8 +16,6 @@ class BaseViewController<T: BaseHeaderView,
     let headerView: T
     let mainView: P
     
-    final var disposeBag = DisposeBag()
-    
     //MARK: - Generator
     
     init(headerView: T, mainView: P){
@@ -29,6 +27,8 @@ class BaseViewController<T: BaseHeaderView,
     required init?(coder: NSCoder) {
         fatalError()
     }
+    
+    final let disposeBag = DisposeBag()
     
     //MARK: - LifeCycle
 

--- a/Zatch/Global/Source/Base/ViewController/BaseViewController.swift
+++ b/Zatch/Global/Source/Base/ViewController/BaseViewController.swift
@@ -33,31 +33,28 @@ class BaseViewController<T: BaseHeaderView,
     //MARK: - LifeCycle
 
     override func viewDidLoad() {
-        
         super.viewDidLoad()
-
         style()
         layout()
         initialize()
         bind()
     }
+    //MARK: - Template Method
     
     func style() {
-        self.view.backgroundColor = .white
-        self.tabBarController?.tabBar.isHidden = true
-        self.navigationController?.isNavigationBarHidden = true
+        view.backgroundColor = .white
+        tabBarController?.tabBar.isHidden = true
+        navigationController?.isNavigationBarHidden = true
     }
     
     func layout() {
-        
-        self.view.addSubview(headerView)
-        self.view.addSubview(mainView)
+        view.addSubview(headerView)
+        view.addSubview(mainView)
         
         headerView.snp.makeConstraints{
             $0.top.equalToSuperview().offset(Const.Offset.headerTop)
             $0.leading.trailing.equalToSuperview()
         }
-        
         mainView.snp.makeConstraints{
             $0.top.equalTo(headerView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
@@ -74,6 +71,6 @@ class BaseViewController<T: BaseHeaderView,
     //MARK: - Action
     
     @objc func viewControllerWillPop(){
-        self.navigationController?.popViewController(animated: true)
+        navigationController?.popViewController(animated: true)
     }
 }

--- a/Zatch/Global/Source/BottomSheet/BaseBottomSheetViewController.swift
+++ b/Zatch/Global/Source/BottomSheet/BaseBottomSheetViewController.swift
@@ -41,7 +41,7 @@ class BaseBottomSheetViewController<T>: UIViewController, UIViewControllerTransi
         
         let controller: UISheetPresentationController = .init(presentedViewController: presented, presenting: presenting)
         
-        let detent: UISheetPresentationController.Detent = ._detent(withIdentifier: "Detent1", constant: type.sheetHeight * Const.Device.DEVICE_HEIGHT / 810)
+        let detent: UISheetPresentationController.Detent = ._detent(withIdentifier: "Detent1", constant: type.sheetHeight * Device.height / 810)
     
         controller.detents = [detent]
         controller.preferredCornerRadius = 28

--- a/Zatch/Global/Source/BottomSheet/SheetNavigationViewController.swift
+++ b/Zatch/Global/Source/BottomSheet/SheetNavigationViewController.swift
@@ -25,7 +25,7 @@ class SheetNavigationViewController: UINavigationController, UIViewControllerTra
 
         let controller: UISheetPresentationController = .init(presentedViewController: presented, presenting: presenting)
 
-        let detent: UISheetPresentationController.Detent = ._detent(withIdentifier: "Test1", constant: 324 * Const.Device.DEVICE_HEIGHT / 810)
+        let detent: UISheetPresentationController.Detent = ._detent(withIdentifier: "Test1", constant: 324 * Device.height / 810)
 
         controller.detents = [detent]
         controller.preferredCornerRadius = 28

--- a/Zatch/Global/Source/Const.swift
+++ b/Zatch/Global/Source/Const.swift
@@ -8,12 +8,7 @@
 import Foundation
 
 struct Const{
-    
-    struct Device{
-        static let DEVICE_WIDTH = UIScreen.main.bounds.size.width
-        static let DEVICE_HEIGHT = UIScreen.main.bounds.size.height
-    }
-    
+    static let isSmallDevice = height <= 736
     struct KakaoAPI{
         static let KAKAO_APP_KEY: String = Bundle.main.object(forInfoDictionaryKey: "KAKAO_APP_KEY") as! String
         static let KAKAO_REST_API_KEY: String = Bundle.main.object(forInfoDictionaryKey: "KAKAO_REST_API_KEY") as! String
@@ -29,6 +24,12 @@ struct Const{
         static let mainViewTopOffset: CGFloat = 107
         static let profileImageSize: CGFloat = 116
     }
+}
+
+
+struct Device{
+    static let width = UIScreen.main.bounds.size.width
+    static let height = UIScreen.main.bounds.size.height
 }
 
 struct ViewTag{

--- a/Zatch/Global/Source/Const.swift
+++ b/Zatch/Global/Source/Const.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct Const{
-    static let isSmallDevice = height <= 736
     struct KakaoAPI{
         static let KAKAO_APP_KEY: String = Bundle.main.object(forInfoDictionaryKey: "KAKAO_APP_KEY") as! String
         static let KAKAO_REST_API_KEY: String = Bundle.main.object(forInfoDictionaryKey: "KAKAO_REST_API_KEY") as! String
@@ -28,6 +27,7 @@ struct Const{
 
 
 struct Device{
+    static let isSmallDevice = height <= 736
     static let width = UIScreen.main.bounds.size.width
     static let height = UIScreen.main.bounds.size.height
 }

--- a/Zatch/Presentation/Cells/ChattingCells/LeftChattingImageTableViewCell.swift
+++ b/Zatch/Presentation/Cells/ChattingCells/LeftChattingImageTableViewCell.swift
@@ -69,7 +69,7 @@ class LeftChattingImageTableViewCell: BaseTableViewCell {
             $0.top.equalTo(userNameLabel.snp.bottom).offset(7)
             $0.leading.equalTo(profileImage.snp.trailing).offset(8)
             $0.bottom.equalToSuperview()
-            $0.width.height.lessThanOrEqualTo(200 / 360 * Const.Device.DEVICE_WIDTH)
+            $0.width.height.lessThanOrEqualTo(200 / 360 * Device.width)
         }
         
         timeLabel.snp.makeConstraints{

--- a/Zatch/Presentation/Cells/ChattingCells/RightChattingImageTableViewCell.swift
+++ b/Zatch/Presentation/Cells/ChattingCells/RightChattingImageTableViewCell.swift
@@ -51,7 +51,7 @@ class RightChattingImageTableViewCell: BaseTableViewCell {
         imageMessageView.snp.makeConstraints{
             $0.trailing.equalToSuperview()
             $0.top.bottom.equalToSuperview()
-            $0.width.height.lessThanOrEqualTo(200 / 360 * Const.Device.DEVICE_WIDTH)
+            $0.width.height.lessThanOrEqualTo(200 / 360 * Device.width)
         }
     }
 }

--- a/Zatch/Presentation/Cells/DetailCells/DetailImageTableViewCell.swift
+++ b/Zatch/Presentation/Cells/DetailCells/DetailImageTableViewCell.swift
@@ -81,8 +81,8 @@ extension DetailImageTableViewCell: UIScrollViewDelegate{
             let imageView = UIImageView().then{
                 $0.backgroundColor = .black45
             }
-            let xPos = Const.Device.DEVICE_WIDTH * CGFloat(i)
-            imageView.frame = CGRect(x: xPos, y: 0, width: Const.Device.DEVICE_WIDTH, height: Const.Device.DEVICE_WIDTH)
+            let xPos = Device.width * CGFloat(i)
+            imageView.frame = CGRect(x: xPos, y: 0, width: Device.width, height: Device.width)
 //            imageView.image = images[i]
             scrollView.addSubview(imageView)
             scrollView.contentSize.width = imageView.frame.width * CGFloat(i + 1)
@@ -100,7 +100,7 @@ extension DetailImageTableViewCell: UIScrollViewDelegate{
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let value = scrollView.contentOffset.x/Const.Device.DEVICE_WIDTH
+        let value = scrollView.contentOffset.x/Device.width
         setPageControlSelectedPage(currentPage: Int(round(value)))
     }
 }

--- a/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductDateChoiceTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductDateChoiceTableViewCell.swift
@@ -7,11 +7,26 @@
 
 import Foundation
 
-class ProductDateChoiceTableViewCell: BaseTableViewCell {
+protocol ProductRegisterDelegate{
+    func dateNotConfirmed(about type: Register.ProductDate)
+}
+
+final class ProductDateChoiceTableViewCell: BaseTableViewCell {
     
-    let backView = UIView()
+    var productDateType: Register.ProductDate!{
+        didSet{
+            titleLabel.text = productDateType.rawValue
+        }
+    }
     
-    let titleLabel = UILabel().then{
+    var isNotConfirmed: Bool{
+        checkButton.isSelected
+    }
+    
+    var delegate: ProductRegisterDelegate!
+    
+    private let backView = UIView()
+    private let titleLabel = UILabel().then{
         $0.font = UIFont.pretendard(size: 14, family: .Medium)
         $0.textColor = .black
     }
@@ -172,27 +187,32 @@ class ProductDateChoiceTableViewCell: BaseTableViewCell {
         }
     }
     
-    @objc func checkButtonListener(_ sender: ZatchRoundCheck){
-        
-        if(sender.isSelected){
-            sender.isSelected = false
-            stackView.isUserInteractionEnabled = true
-            labelArray.forEach{ label in
-                label.textColor = .black
-            }
-        }else{
-            sender.isSelected = true
-            labelArray.forEach{ label in
-                label.textColor = .black20
-            }
-            textFieldArray.forEach{ label in
-                label.text = ""
-            }
+    @objc private func checkButtonListener(_ sender: ZatchRoundCheck){
+        sender.isSelected.toggle()
+        sender.isSelected ? setNotConfirmedState() : setDateSelectedState()
+    }
+    
+    private func setNotConfirmedState(){
+        labelArray.forEach{ label in
+            label.textColor = .black20
+        }
+        delegate.dateNotConfirmed(about: productDateType)
+    }
+    
+    private func setDateSelectedState(){
+        stackView.isUserInteractionEnabled = true
+        labelArray.forEach{ label in
+            label.textColor = .black
         }
     }
     
-    func setTitle(type: RegisterProductInfoTestViewController.ProductDate){
-        titleLabel.text = type.rawValue
+    func setDate(_ date: Register.DateString?){
+        guard let date = date else {
+            textFieldArray.forEach{ $0.text = "" }; return
+        }
+        yearTextField.text = date.year
+        monthTextField.text = date.month
+        dateTextField.text = date.date
     }
 
 }

--- a/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductDateChoiceTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductDateChoiceTableViewCell.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 class ProductDateChoiceTableViewCell: BaseTableViewCell {
     
     let backView = UIView()
@@ -205,7 +204,7 @@ class ProductDateChoiceTableViewCell: BaseTableViewCell {
         }
     }
     
-    func setTitle(type: ProductDetailInputTableViewCell.ProductDate){
+    func setTitle(type: RegisterProductInfoTestViewController.ProductDate){
         titleLabel.text = type.rawValue
     }
 

--- a/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductDateChoiceTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductDateChoiceTableViewCell.swift
@@ -7,10 +7,6 @@
 
 import Foundation
 
-protocol ProductRegisterDelegate{
-    func dateNotConfirmed(about type: Register.ProductDate)
-}
-
 final class ProductDateChoiceTableViewCell: BaseTableViewCell {
     
     var productDateType: Register.ProductDate!{
@@ -23,7 +19,7 @@ final class ProductDateChoiceTableViewCell: BaseTableViewCell {
         checkButton.isSelected
     }
     
-    var delegate: ProductRegisterDelegate!
+    var delegate: ZatchRegisterDelegate!
     
     private let backView = UIView()
     private let titleLabel = UILabel().then{

--- a/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductDateChoiceTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductDateChoiceTableViewCell.swift
@@ -16,91 +16,78 @@ class ProductDateChoiceTableViewCell: BaseTableViewCell {
         $0.textColor = .black
     }
     
-    let yearTextField = UILabel().then{
+    private let yearTextField = UILabel().then{
         $0.font = UIFont.pretendard(size: 14, family: .Medium)
         $0.textColor = .black85
         $0.textAlignment = .center
     }
-    let yearLabel = UILabel().then{
+    private let yearLabel = UILabel().then{
         $0.text = "년"
         $0.font = UIFont.pretendard(size: 14, family: .Medium)
         $0.textColor = .black
     }
-    let yearBorderLine = UIView().then{
+    private let yearBorderLine = UIView().then{
         $0.backgroundColor = .black5
     }
     
-    let monthTextField = UILabel().then{
+    private let monthTextField = UILabel().then{
         $0.font = UIFont.pretendard(size: 14, family: .Medium)
         $0.textColor = .black85
         $0.textAlignment = .center
     }
-    let monthLabel = UILabel().then{
+    private let monthLabel = UILabel().then{
         $0.text = "월"
         $0.font = UIFont.pretendard(size: 14, family: .Medium)
         $0.textColor = .black
     }
-    let monthBorderLine = UIView().then{
+    private let monthBorderLine = UIView().then{
         $0.backgroundColor = .black5
     }
     
-    let dateTextField = UILabel().then{
+    private let dateTextField = UILabel().then{
         $0.font = UIFont.pretendard(size: 14, family: .Medium)
         $0.textColor = .black85
         $0.textAlignment = .center
     }
-    let dateLabel = UILabel().then{
+    private let dateLabel = UILabel().then{
         $0.text = "일"
         $0.font = UIFont.pretendard(size: 14, family: .Medium)
         $0.textColor = .black
     }
-    let dateBorderLine = UIView().then{
+    private let dateBorderLine = UIView().then{
         $0.backgroundColor = .black5
     }
     
-    let checkButton = ZatchRoundCheck().then{
+    private let checkButton = ZatchRoundCheck().then{
         $0.addTarget(self, action: #selector(checkButtonListener(_:)), for: .touchUpInside)
     }
-    let checkButtonLabel = UILabel().then{
+    private let checkButtonLabel = UILabel().then{
         $0.text = "확인 불가"
         $0.font = UIFont.pretendard(size: 14, family: .Medium)
         $0.textColor = .black
     }
     
     //stack view
-    let stackView = UIStackView().then{
+    private let stackView = UIStackView().then{
         $0.axis = .horizontal
         $0.spacing = 13
         $0.distribution = .equalSpacing
     }
-    let yearStack = UIStackView().then{
+    private let yearStack = UIStackView().then{
         $0.axis = .horizontal
         $0.spacing = 4
     }
-    let monthStack = UIStackView().then{
+    private let monthStack = UIStackView().then{
         $0.axis = .horizontal
         $0.spacing = 4
     }
-    let dateStack = UIStackView().then{
+    private let dateStack = UIStackView().then{
         $0.axis = .horizontal
         $0.spacing = 4
     }
     
-    var labelArray : [UILabel]!
-    var textFieldArray: [UILabel]!
-    
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        
-        labelArray = [titleLabel,yearLabel,monthLabel,dateLabel]
-        textFieldArray = [yearTextField,monthTextField,dateTextField]
-
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+    private lazy var labelArray = [titleLabel,yearLabel,monthLabel,dateLabel]
+    private lazy var textFieldArray = [yearTextField,monthTextField,dateTextField]
     
     override func hierarchy() {
         

--- a/Zatch/Presentation/Cells/RegisterCells/TextFieldTabeViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/TextFieldTabeViewCell.swift
@@ -11,12 +11,27 @@ import RxCocoa
 
 class TextFieldTabeViewCell: BaseTableViewCell, DefaultObservable {
     
+    enum CellTypeTest{
+        case product
+        case question
+    }
+    
     enum CellType{
         case myProduct
         case firstPriority
         case secondPriority
         case thirdPriority
         case question
+    }
+    
+    var informationTypeTest: CellTypeTest?{
+        didSet{
+            textField.placeholder = informationTypeTest?.placeholder
+        }
+    }
+    
+    var textObservable: Observable<String>!{
+        textField.rx.text.orEmpty.asObservable()
     }
     
     var informationType: CellType!{
@@ -75,11 +90,11 @@ class TextFieldTabeViewCell: BaseTableViewCell, DefaultObservable {
     }
     
     func bind(){
-        let input: Observable<String> = textField.rx.text.orEmpty.asObservable()
-        input.asDriver(onErrorJustReturn: "")
-            .drive{
-                self.setProductNameToManager($0)
-            }.disposed(by: disposeBag)
+//        let input: Observable<String> = textField.rx.text.orEmpty.asObservable()
+//        input.asDriver(onErrorJustReturn: "")
+//            .drive{
+//                self.setProductNameToManager($0)
+//            }.disposed(by: disposeBag)
     }
     
     private func setProductNameToManager(_ product: String){
@@ -103,6 +118,14 @@ class TextFieldTabeViewCell: BaseTableViewCell, DefaultObservable {
 
 }
 
+extension TextFieldTabeViewCell.CellTypeTest{
+    var placeholder: String{
+        switch self{
+        case .product:      return "상품 이름을 입력해주세요."
+        case .question:     return "제목을 입력해주세요."
+        }
+    }
+}
 
 extension TextFieldTabeViewCell.CellType{
     var placeholder: String{

--- a/Zatch/Presentation/Utils/Register/Register.swift
+++ b/Zatch/Presentation/Utils/Register/Register.swift
@@ -1,0 +1,18 @@
+//
+//  Register.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/04/11.
+//
+
+import Foundation
+
+struct Register{
+    @frozen
+    enum ProductDate: String{
+        case buy = "구매일자"
+        case end = "유통기한"
+    }
+    
+    typealias DateString = (year: String, month: String, date: String)
+}

--- a/Zatch/Presentation/Utils/Register/Register.swift
+++ b/Zatch/Presentation/Utils/Register/Register.swift
@@ -14,5 +14,20 @@ struct Register{
         case end = "유통기한"
     }
     
+    @frozen
+    enum ProductOpenState: Int{
+        case open = 1
+        case unopen = 2
+    }
+    
     typealias DateString = (year: String, month: String, date: String)
+}
+
+extension Register.ProductOpenState{
+    var title: String{
+        switch self{
+        case .unopen:   return "미개봉"
+        case .open:     return "개봉"
+        }
+    }
 }

--- a/Zatch/Presentation/Utils/Register/ZatchRegisterDelegate.swift
+++ b/Zatch/Presentation/Utils/Register/ZatchRegisterDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  ZatchRegisterDelegate.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/04/11.
+//
+
+import Foundation
+
+protocol ZatchRegisterDelegate{
+    func changeIsOpenState(_ state: Int)
+    func dateNotConfirmed(about type: Register.ProductDate)
+}

--- a/Zatch/Presentation/ViewControllers/Register/RegisterProductInfoTestViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterProductInfoTestViewController.swift
@@ -56,15 +56,7 @@ final class RegisterProductInfoTestViewController: BaseViewController<LeftNaviga
     
     override func initialize(){
         super.initialize()
-        setTableViewDelegate()
-    }
-    
-    private func setTableViewDelegate(){
-        mainView.backTableView.do{
-            $0.dataSource = self
-            $0.delegate = self
-            $0.separatorStyle = .none
-        }
+        mainView.backTableView.initializeDelegate(self)
     }
     
     override func bindAfterViewAppear() {
@@ -144,7 +136,7 @@ extension RegisterProductInfoTestViewController: UITableViewDelegate, UITableVie
         case 1:         return getDateSelectTableViewCell(about: .buy, indexPath: indexPath)
         case 2:         return getDateSelectTableViewCell(about: .end, indexPath: indexPath)
         case 3:         return getProductIsOpenTableViewCell(indexPath: indexPath)
-        default:    fatalError("재치 등록 section 0 TableView Cell indexPath 오류")
+        default:        fatalError("재치 등록 section 0 TableView Cell indexPath 오류")
         }
     }
     

--- a/Zatch/Presentation/ViewControllers/Register/RegisterProductInfoTestViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterProductInfoTestViewController.swift
@@ -1,0 +1,183 @@
+//
+//  RegisterProductInfoTestViewController.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/04/11.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+final class RegisterProductInfoTestViewController: BaseViewController<LeftNavigationHeaderView, ZatchRegisterFirstView>{
+    
+    //MARK: - Generator
+    
+    init(){
+        super.init(headerView: LeftNavigationHeaderView(title: "재치 등록하기"),
+                   mainView: ZatchRegisterFirstView())
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(headerView: LeftNavigationHeaderView(title: "재치 등록하기"),
+                   mainView: ZatchRegisterFirstView())
+    }
+    
+    //MARK: - Property
+    
+    @frozen
+    enum ProductDate: String{
+        case buy = "구매일자"
+        case end = "유통기한"
+    }
+    
+    private var isDetailCellOpen = false{
+        didSet{
+            mainView.backTableView.isScrollEnabled = isDetailCellOpen
+            mainView.backTableView.cellForRow(at: DETAIL_OPEN_CELL_INDEX, cellType: RegisterCategorySelectTableViewCell.self).isSubViewOpen = isDetailCellOpen
+            mainView.backTableView.reloadSections(IndexSet.init(integer: 1), with: .automatic)
+        }
+    }
+    
+    private let CATEGORY_CELL_INDEX: IndexPath = [0,0]
+    private let PRODUCT_NAME_CELL_INDEX: IndexPath = [0,1]
+    private let DETAIL_OPEN_CELL_INDEX: IndexPath = [0,3]
+    
+    private let viewModel = FirstRegisterTestViewModel()
+    private let categoryBottomSheet = CategorySheetViewController()
+    
+    private let categoryRelay = PublishRelay<Int>()
+    private let countSubject = PublishSubject<String>()
+    private let buyDateSubject = PublishSubject<String>()
+    private let endDateSubject = PublishSubject<String>()
+    private let isOpenSubject = BehaviorRelay<Bool>(value: false)
+    
+    //MARK: - Template Method
+    
+    override func initialize(){
+        super.initialize()
+        setTableViewDelegate()
+    }
+    
+    private func setTableViewDelegate(){
+        mainView.backTableView.do{
+            $0.dataSource = self
+            $0.delegate = self
+            $0.separatorStyle = .none
+        }
+    }
+    
+    override func bindAfterViewAppear() {
+        
+        viewModel.textFieldObservable = mainView.backTableView
+            .cellForRow(at: PRODUCT_NAME_CELL_INDEX,
+                        cellType: TextFieldTabeViewCell.self)
+            .textObservable
+        
+        categoryRelay
+            .subscribe(onNext: {
+                self.mainView.backTableView
+                    .cellForRow(at: self.CATEGORY_CELL_INDEX,
+                                cellType: RegisterCategorySelectTableViewCell.self)
+                    .setCategoryTitle(id: $0)
+            }).disposed(by: disposeBag)
+        
+        
+        let input = FirstRegisterTestViewModel.Input(categoryId: categoryRelay.asObservable())
+        _ = viewModel.transform(input)
+    }
+}
+
+//MARK: - UITableViewDelegate
+
+extension RegisterProductInfoTestViewController: UITableViewDelegate, UITableViewDataSource{
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        2
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        section == 0 ? 4 : isDetailCellOpen ? 4 : 0
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch indexPath.section{
+        case 0:     return getBasicInformationCells(indexPath: indexPath)
+        case 1:     return getDetailInformationCells(indexPath: indexPath)
+        default:    fatalError("재치 등록 TableView Cell indexPath 오류")
+        }
+    }
+    
+    private func getBasicInformationCells(indexPath: IndexPath) -> BaseTableViewCell{
+        switch indexPath.row{
+        case 0:     return getCategorySelectTableViewCell(indexPath: indexPath)
+        case 1:     return getTextFieldTableViewCell(indexPath: indexPath)
+        case 2:     return getImageAddTableViewCell(indexPath: indexPath)
+        case 3:     return getRegisterCategorySelectTableViewCell(indexPath: indexPath)
+        default:    fatalError("재치 등록 section 0 TableView Cell indexPath 오류")
+        }
+    }
+    
+    private func getCategorySelectTableViewCell(indexPath: IndexPath) -> BaseTableViewCell{
+        return mainView.backTableView.dequeueReusableCell(for: indexPath, cellType: RegisterCategorySelectTableViewCell.self)
+    }
+    
+    private func getTextFieldTableViewCell(indexPath: IndexPath) -> BaseTableViewCell{
+        return mainView.backTableView.dequeueReusableCell(for: indexPath, cellType: TextFieldTabeViewCell.self).then{
+            $0.informationTypeTest = .product
+        }
+    }
+    
+    private func getImageAddTableViewCell(indexPath: IndexPath) -> BaseTableViewCell{
+        return mainView.backTableView.dequeueReusableCell(for: indexPath, cellType: ImageAddTableViewCell.self)
+    }
+    
+    private func getRegisterCategorySelectTableViewCell(indexPath: IndexPath) -> BaseTableViewCell{
+        return mainView.backTableView.dequeueReusableCell(for: indexPath, cellType: RegisterCategorySelectTableViewCell.self).then{
+            $0.setDefaultTitle("입력사항 더보기")
+        }
+    }
+    
+    private func getDetailInformationCells(indexPath: IndexPath) -> BaseTableViewCell{
+        switch indexPath.row{
+        case 0:         return getProductQuantityTableViewCell(indexPath: indexPath)
+        case 1:         return getDateSelectTableViewCell(about: .buy, indexPath: indexPath)
+        case 2:         return getDateSelectTableViewCell(about: .end, indexPath: indexPath)
+        case 3:         return getProductIsOpenTableViewCell(indexPath: indexPath)
+        default:    fatalError("재치 등록 section 0 TableView Cell indexPath 오류")
+        }
+    }
+    
+    private func getProductQuantityTableViewCell(indexPath: IndexPath) -> BaseTableViewCell{
+        return mainView.backTableView.dequeueReusableCell(for: indexPath, cellType: ProductQuantityTableViewCell.self)
+    }
+    
+    private func getDateSelectTableViewCell(about type: ProductDate,indexPath: IndexPath) -> BaseTableViewCell{
+        return mainView.backTableView.dequeueReusableCell(for: indexPath, cellType: ProductDateChoiceTableViewCell.self).then{
+            $0.setTitle(type: type)
+        }
+    }
+    
+    private func getProductIsOpenTableViewCell(indexPath: IndexPath) -> BaseTableViewCell{
+        return mainView.backTableView.dequeueReusableCell(for: indexPath, cellType: ProductIsOpenTableViewCell.self)
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        view.endEditing(true)
+        switch indexPath{
+        case CATEGORY_CELL_INDEX:
+            categoryBottomSheetWillOpen()
+        case DETAIL_OPEN_CELL_INDEX:
+            isDetailCellOpen.toggle()
+        default:
+            return
+        }
+    }
+    
+    private func categoryBottomSheetWillOpen(){
+        categoryBottomSheet.show(in: self)
+        categoryBottomSheet.completion = { [weak self] in
+            self?.categoryRelay.accept($0)
+        }
+    }
+}

--- a/Zatch/Presentation/ViewControllers/Register/RegisterProductInfoTestViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterProductInfoTestViewController.swift
@@ -25,13 +25,7 @@ final class RegisterProductInfoTestViewController: BaseViewController<LeftNaviga
     
     //MARK: - Property
     
-    @frozen
-    enum ProductDate: String{
-        case buy = "구매일자"
-        case end = "유통기한"
-    }
-    
-    private var isDetailCellOpen = false{
+    private var isDetailCellOpen = false {
         didSet{
             mainView.backTableView.cellForRow(at: DETAIL_OPEN_CELL_INDEX, cellType: RegisterCategorySelectTableViewCell.self).isSubViewOpen = isDetailCellOpen
             mainView.backTableView.reloadSections(IndexSet.init(integer: 1), with: .automatic)
@@ -144,7 +138,7 @@ extension RegisterProductInfoTestViewController: UITableViewDelegate, UITableVie
         return mainView.backTableView.dequeueReusableCell(for: indexPath, cellType: ProductQuantityTableViewCell.self)
     }
     
-    private func getDateSelectTableViewCell(about type: ProductDate,indexPath: IndexPath) -> BaseTableViewCell{
+    private func getDateSelectTableViewCell(about type: Register.ProductDate, indexPath: IndexPath) -> BaseTableViewCell{
         return mainView.backTableView.dequeueReusableCell(for: indexPath, cellType: ProductDateChoiceTableViewCell.self).then{
             $0.setTitle(type: type)
         }

--- a/Zatch/Presentation/ViewControllers/Register/RegisterProductInfoTestViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterProductInfoTestViewController.swift
@@ -33,9 +33,9 @@ final class RegisterProductInfoTestViewController: BaseViewController<LeftNaviga
     
     private var isDetailCellOpen = false{
         didSet{
-            mainView.backTableView.isScrollEnabled = isDetailCellOpen
             mainView.backTableView.cellForRow(at: DETAIL_OPEN_CELL_INDEX, cellType: RegisterCategorySelectTableViewCell.self).isSubViewOpen = isDetailCellOpen
             mainView.backTableView.reloadSections(IndexSet.init(integer: 1), with: .automatic)
+            mainView.backTableView.isScrollEnabled = Device.isSmallDevice ? true : isDetailCellOpen
         }
     }
     

--- a/Zatch/Presentation/ViewModels/Register/FirstRegisterTestViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Register/FirstRegisterTestViewModel.swift
@@ -21,10 +21,15 @@ struct RegisterFirstInformationDTO{
 
 final class FirstRegisterTestViewModel: BaseViewModel{
     
-    var textFieldObservable: Observable<String>!
+    var productName: Observable<String>!
+    
+    private let disposeBag = DisposeBag()
     
     struct Input{
         let categoryId: Observable<Int>
+        let buyDate: Observable<Register.DateString?>
+        let endDate: Observable<Register.DateString?>
+        let isOpen: Observable<Int>
     }
     
     struct Output{
@@ -32,10 +37,18 @@ final class FirstRegisterTestViewModel: BaseViewModel{
     }
     
     func transform(_ input: Input) -> Output {
-        Observable.combineLatest(textFieldObservable, input.categoryId)
-            .subscribe(onNext: {
-                print($0, $1)
-            })
+        
+        
+        
+        let requestObservable = Observable.combineLatest(input.categoryId,
+                                                         productName,
+                                                         input.buyDate,
+                                                         input.endDate,
+                                                         input.isOpen)
+            .map{
+                return $0
+            }.asObservable()
+        
         return Output()
     }
 }

--- a/Zatch/Presentation/ViewModels/Register/FirstRegisterTestViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Register/FirstRegisterTestViewModel.swift
@@ -1,0 +1,44 @@
+//
+//  FirstRegisterTestViewModel.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/04/11.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+struct RegisterFirstInformationDTO{
+    let category: Int
+    let productName: String
+    let image: UIImage
+    let count: String
+    let buyDate: String
+    let endDate: String
+    let isOpen: Bool
+}
+
+final class FirstRegisterTestViewModel: BaseViewModel{
+    
+    var textFieldObservable: Observable<String>!
+    
+    struct Input{
+        let categoryId: Observable<Int>
+    }
+    
+    struct Output{
+        
+    }
+    
+    func transform(_ input: Input) -> Output {
+        Observable.combineLatest(textFieldObservable, input.categoryId)
+            .subscribe(onNext: {
+                print($0, $1)
+            })
+        return Output()
+    }
+}
+
+extension FirstRegisterTestViewModel{
+}

--- a/Zatch/Presentation/Views/RegisterView/ZatchRegisterFirstView.swift
+++ b/Zatch/Presentation/Views/RegisterView/ZatchRegisterFirstView.swift
@@ -16,10 +16,14 @@ class ZatchRegisterFirstView: BaseView {
         $0.showsVerticalScrollIndicator = false
         $0.isScrollEnabled = false
         
-        $0.register(RegisterCategorySelectTableViewCell.self, forCellReuseIdentifier: RegisterCategorySelectTableViewCell.cellIdentifier)
-        $0.register(TextFieldTabeViewCell.self, forCellReuseIdentifier: TextFieldTabeViewCell.cellIdentifier)
-        $0.register(ImageAddTableViewCell.self, forCellReuseIdentifier: ImageAddTableViewCell.cellIdentifier)
-        $0.register(ProductDetailInputTableViewCell.self, forCellReuseIdentifier: ProductDetailInputTableViewCell.cellIdentifier)
+        $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 80, right: 0)
+        
+        $0.register(cellType: RegisterCategorySelectTableViewCell.self)
+        $0.register(cellType: TextFieldTabeViewCell.self)
+        $0.register(cellType: ImageAddTableViewCell.self)
+        $0.register(cellType: ProductQuantityTableViewCell.self)
+        $0.register(cellType: ProductDateChoiceTableViewCell.self)
+        $0.register(cellType: ProductIsOpenTableViewCell.self)
     }
     
     lazy var nextButton = Purple36Button(title: "다음 단계로")

--- a/Zatch/Presentation/Views/RegisterView/ZatchRegisterFirstView.swift
+++ b/Zatch/Presentation/Views/RegisterView/ZatchRegisterFirstView.swift
@@ -10,7 +10,7 @@ import UIKit
 class ZatchRegisterFirstView: BaseView {
     
     //MARK: - UI
-    let topView = TopTitleView(title: "주고 싶은\n물건이 무엇인가요?")
+    private let topView = TopTitleView(title: "주고 싶은\n물건이 무엇인가요?")
     
     let backTableView = UITableView().then{
         $0.showsVerticalScrollIndicator = false
@@ -27,36 +27,22 @@ class ZatchRegisterFirstView: BaseView {
     }
     
     lazy var nextButton = Purple36Button(title: "다음 단계로")
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
-        style()
-        hierarchy()
-        layout()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
     
     override func hierarchy() {
-        self.addSubview(topView)
-        self.addSubview(backTableView)
-        self.addSubview(nextButton)
+        addSubview(topView)
+        addSubview(backTableView)
+        addSubview(nextButton)
     }
     
     override func layout() {
         topView.snp.makeConstraints{ make in
             make.top.leading.trailing.equalToSuperview()
         }
-        
         backTableView.snp.makeConstraints{ make in
             make.width.equalToSuperview()
             make.top.equalTo(topView.snp.bottom)
             make.bottom.equalTo(nextButton.snp.top).offset(-5)
         }
-        
         nextButton.snp.makeConstraints{ make in
             make.leading.equalToSuperview().offset(74)
             make.centerX.equalToSuperview()


### PR DESCRIPTION
## What is this PR? 🔍
재치 등록 ViewModel 활용 리팩토링 일부 완료

## Key Changes 🔑

### 1. ViewModel 활용 위한 테스트 클래스 생성 및 리팩토링 진행
+ VC에서 Subject/Relay 통해 Observable element들을 모으도록 하였고, TextField의 경우 Observable 통해 viewModel 프로퍼티에 바인딩 시켰습니다. 

### 2. ZatchRepository, RegisterUseCase 메서드 추가 및 임시 구현

### 3. Register Util 파일 생성
+ 재치 등록 프로세스에서 공통적으로 사용되거나 VC/ViewModel/View를 넘나들며 사용되는 리터럴 값 등을 관리하기 위해 파일 추가했으며, 필요한 기능들 선언해놨습니다. 

남은 부분들은 수량/이미지 등이 있는데, 이 부분은 UI가 아직 완전치 않은 것 같아서 보류합니다. 

## Related Issues ⛱
#218
