### PR TITLE
Refactor/#218: 재치 등록 2번째 프로세스(받고 싶은 물건 입력) ViewModel 적용 리팩토링 완료

### DIFF
--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -263,10 +263,14 @@
 		57FFEDC728DD2F1B0041719B /* CheckExchangeRegisterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFEDC628DD2F1B0041719B /* CheckExchangeRegisterViewController.swift */; };
 		6AF93CFE86982B0FFAF29206 /* Pods_Zatch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99A9FAD0C12F2252FE5C8E69 /* Pods_Zatch.framework */; };
 		D1533A389FEC70B77AD110F6 /* Pods_ZatchTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2828C8E20374F7AEAB414182 /* Pods_ZatchTests.framework */; };
-		EE0AD54529E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54429E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift */; };
-		EE0AD54729E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54629E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift */; };
+		EE0AD54529E4FCF600C1CDA1 /* RegisterFirstInfoTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54429E4FCF600C1CDA1 /* RegisterFirstInfoTestViewModel.swift */; };
+		EE0AD54729E5033400C1CDA1 /* RegisterFirstInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54629E5033400C1CDA1 /* RegisterFirstInfoViewController.swift */; };
 		EE0AD54929E542A400C1CDA1 /* Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54829E542A400C1CDA1 /* Register.swift */; };
 		EE0AD54B29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54A29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift */; };
+		EE0AD54F29E6DB9F00C1CDA1 /* RegisterSecondInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54E29E6DB9F00C1CDA1 /* RegisterSecondInfoViewModel.swift */; };
+		EE0AD55129E6DBB100C1CDA1 /* RegisterSecondInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD55029E6DBB100C1CDA1 /* RegisterSecondInfoViewController.swift */; };
+		EE0AD55529E8220300C1CDA1 /* RegisterPriorityTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD55429E8220300C1CDA1 /* RegisterPriorityTableViewCell.swift */; };
+		EE0AD55729E8225C00C1CDA1 /* AnyZatchSelectTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD55629E8225C00C1CDA1 /* AnyZatchSelectTableViewCell.swift */; };
 		EE0D8E4B29B73CE000D96050 /* NoticeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D8E4A29B73CE000D96050 /* NoticeDetailView.swift */; };
 		EE0D8E4D29B7561200D96050 /* TableOnlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D8E4C29B7561200D96050 /* TableOnlyView.swift */; };
 		EE27C54529C826E000285CC5 /* SearchRepositotyInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE27C54429C826E000285CC5 /* SearchRepositotyInterface.swift */; };
@@ -666,10 +670,14 @@
 		6E2CF233E53955D92629E42D /* Pods-Zatch-ZatchUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zatch-ZatchUITests.release.xcconfig"; path = "Target Support Files/Pods-Zatch-ZatchUITests/Pods-Zatch-ZatchUITests.release.xcconfig"; sourceTree = "<group>"; };
 		99A9FAD0C12F2252FE5C8E69 /* Pods_Zatch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Zatch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E93BEB6442FCA2A68AFE12C0 /* Pods-Zatch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zatch.debug.xcconfig"; path = "Target Support Files/Pods-Zatch/Pods-Zatch.debug.xcconfig"; sourceTree = "<group>"; };
-		EE0AD54429E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRegisterTestViewModel.swift; sourceTree = "<group>"; };
-		EE0AD54629E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProductInfoTestViewController.swift; sourceTree = "<group>"; };
+		EE0AD54429E4FCF600C1CDA1 /* RegisterFirstInfoTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterFirstInfoTestViewModel.swift; sourceTree = "<group>"; };
+		EE0AD54629E5033400C1CDA1 /* RegisterFirstInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterFirstInfoViewController.swift; sourceTree = "<group>"; };
 		EE0AD54829E542A400C1CDA1 /* Register.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Register.swift; sourceTree = "<group>"; };
 		EE0AD54A29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZatchRegisterDelegate.swift; sourceTree = "<group>"; };
+		EE0AD54E29E6DB9F00C1CDA1 /* RegisterSecondInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterSecondInfoViewModel.swift; sourceTree = "<group>"; };
+		EE0AD55029E6DBB100C1CDA1 /* RegisterSecondInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterSecondInfoViewController.swift; sourceTree = "<group>"; };
+		EE0AD55429E8220300C1CDA1 /* RegisterPriorityTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPriorityTableViewCell.swift; sourceTree = "<group>"; };
+		EE0AD55629E8225C00C1CDA1 /* AnyZatchSelectTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyZatchSelectTableViewCell.swift; sourceTree = "<group>"; };
 		EE0D8E4A29B73CE000D96050 /* NoticeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeDetailView.swift; sourceTree = "<group>"; };
 		EE0D8E4C29B7561200D96050 /* TableOnlyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableOnlyView.swift; sourceTree = "<group>"; };
 		EE27C54429C826E000285CC5 /* SearchRepositotyInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositotyInterface.swift; sourceTree = "<group>"; };
@@ -1104,7 +1112,8 @@
 		23C9031428C5CE6400FB6D3D /* Register */ = {
 			isa = PBXGroup;
 			children = (
-				EE0AD54629E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift */,
+				EE0AD54629E5033400C1CDA1 /* RegisterFirstInfoViewController.swift */,
+				EE0AD55029E6DBB100C1CDA1 /* RegisterSecondInfoViewController.swift */,
 				57600C072963073900A7F27B /* Zatch */,
 			);
 			path = Register;
@@ -1170,6 +1179,8 @@
 				5767D786286ADA4D0075DB28 /* ProductDetailInputTableViewCell.swift */,
 				57EBCE3828A7CD3800212D20 /* ImageRegisterCollectionViewCell.swift */,
 				57EBCE3A28A87BFD00212D20 /* ImageAddBtnCollectionViewCell.swift */,
+				EE0AD55429E8220300C1CDA1 /* RegisterPriorityTableViewCell.swift */,
+				EE0AD55629E8225C00C1CDA1 /* AnyZatchSelectTableViewCell.swift */,
 			);
 			path = RegisterCells;
 			sourceTree = "<group>";
@@ -2089,7 +2100,8 @@
 			isa = PBXGroup;
 			children = (
 				EE642C5C298FAE2C00E15869 /* ZatchRegisterFirstViewModel.swift */,
-				EE0AD54429E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift */,
+				EE0AD54429E4FCF600C1CDA1 /* RegisterFirstInfoTestViewModel.swift */,
+				EE0AD54E29E6DB9F00C1CDA1 /* RegisterSecondInfoViewModel.swift */,
 			);
 			path = Register;
 			sourceTree = "<group>";
@@ -2606,10 +2618,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EE0AD54529E4FCF600C1CDA1 /* FirstRegisterTestViewModel.swift in Sources */,
+				EE0AD54529E4FCF600C1CDA1 /* RegisterFirstInfoTestViewModel.swift in Sources */,
 				EE813FFD29C585400091F16E /* UserRepository.swift in Sources */,
 				EE541C1F29B44F1200DD0F20 /* StatusResponseModel.swift in Sources */,
 				57B32C34291FB58F0018C0CB /* Image.swift in Sources */,
+				EE0AD55729E8225C00C1CDA1 /* AnyZatchSelectTableViewCell.swift in Sources */,
 				5722462B28C77FA5009B7C78 /* SearchAddressResultTableViewCell.swift in Sources */,
 				5767D787286ADA4D0075DB28 /* ProductDetailInputTableViewCell.swift in Sources */,
 				EE33D21E2993E1120020866E /* ZatchComponent.swift in Sources */,
@@ -2621,6 +2634,7 @@
 				57EBCE4028A8906000212D20 /* CancelAlertViewController.swift in Sources */,
 				EE33D21C2993BF710020866E /* LettersAndArrowView.swift in Sources */,
 				574E1CAC2964011D005D2048 /* TypoDesignSystem.swift in Sources */,
+				EE0AD54F29E6DB9F00C1CDA1 /* RegisterSecondInfoViewModel.swift in Sources */,
 				57397FD2296FC0150088B5F4 /* BaseCollectionViewCell.swift in Sources */,
 				EEE6D1622997AFA30004FC7B /* PaddingLabel.swift in Sources */,
 				EEE1154729A747AD003FD4E3 /* MyProfileViewController.swift in Sources */,
@@ -2695,6 +2709,7 @@
 				23B051C528E206C5005D08EA /* MyQuestionsViewController.swift in Sources */,
 				57B5D6D328346AB100EA1439 /* TextFieldTabeViewCell.swift in Sources */,
 				23A86A5B28C73D8600B073CB /* MainCollectionViewTableViewCell.swift in Sources */,
+				EE0AD55129E6DBB100C1CDA1 /* RegisterSecondInfoViewController.swift in Sources */,
 				EE541C2329B45D7200DD0F20 /* ChattingSideSheetView.swift in Sources */,
 				23B7FBB228CED37D0018642E /* TownSettingTableViewCell.swift in Sources */,
 				23B051C328E206B7005D08EA /* RegisterQuestionViewController.swift in Sources */,
@@ -2704,6 +2719,7 @@
 				57A28B3F28CED94B00263079 /* SearchTownViewController.swift in Sources */,
 				57D6D79D28CDBD7A00F805B7 /* ModifyMeetingSheetViewModel.swift in Sources */,
 				57067866281C167100F48342 /* UIFont.swift in Sources */,
+				EE0AD55529E8220300C1CDA1 /* RegisterPriorityTableViewCell.swift in Sources */,
 				EEE326AD2998C60E0017DF46 /* ZatchSearchRequestManager.swift in Sources */,
 				57600C0F296307F600A7F27B /* GatchDetailBottomFixView.swift in Sources */,
 				EE4D887329CFF127003B6383 /* MapRepository.swift in Sources */,
@@ -2765,7 +2781,7 @@
 				EE7AFF5729D16652007872B9 /* MeetingLocationRegisterMapViewController.swift in Sources */,
 				574EC1ED282E62A000E3CE4B /* RegisterCategorySelectTableViewCell.swift in Sources */,
 				57FFEDC528DD2F0D0041719B /* CheckShareRegisterViewController.swift in Sources */,
-				EE0AD54729E5033400C1CDA1 /* RegisterProductInfoTestViewController.swift in Sources */,
+				EE0AD54729E5033400C1CDA1 /* RegisterFirstInfoViewController.swift in Sources */,
 				576341AB28D29D120067D2C5 /* BlockUserTableViewCell.swift in Sources */,
 				EEE6D1652997BF830004FC7B /* ZatchButton.swift in Sources */,
 				57D6D79F28CDC02600F805B7 /* ModifyMeetingSheetViewController.swift in Sources */,

--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -266,7 +266,7 @@
 		EE0AD54529E4FCF600C1CDA1 /* RegisterFirstInfoTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54429E4FCF600C1CDA1 /* RegisterFirstInfoTestViewModel.swift */; };
 		EE0AD54729E5033400C1CDA1 /* RegisterFirstInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54629E5033400C1CDA1 /* RegisterFirstInfoViewController.swift */; };
 		EE0AD54929E542A400C1CDA1 /* Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54829E542A400C1CDA1 /* Register.swift */; };
-		EE0AD54B29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54A29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift */; };
+		EE0AD54B29E5AAEA00C1CDA1 /* RegisterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54A29E5AAEA00C1CDA1 /* RegisterDelegate.swift */; };
 		EE0AD54F29E6DB9F00C1CDA1 /* RegisterSecondInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD54E29E6DB9F00C1CDA1 /* RegisterSecondInfoViewModel.swift */; };
 		EE0AD55129E6DBB100C1CDA1 /* RegisterSecondInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD55029E6DBB100C1CDA1 /* RegisterSecondInfoViewController.swift */; };
 		EE0AD55529E8220300C1CDA1 /* RegisterPriorityTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0AD55429E8220300C1CDA1 /* RegisterPriorityTableViewCell.swift */; };
@@ -673,7 +673,7 @@
 		EE0AD54429E4FCF600C1CDA1 /* RegisterFirstInfoTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterFirstInfoTestViewModel.swift; sourceTree = "<group>"; };
 		EE0AD54629E5033400C1CDA1 /* RegisterFirstInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterFirstInfoViewController.swift; sourceTree = "<group>"; };
 		EE0AD54829E542A400C1CDA1 /* Register.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Register.swift; sourceTree = "<group>"; };
-		EE0AD54A29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZatchRegisterDelegate.swift; sourceTree = "<group>"; };
+		EE0AD54A29E5AAEA00C1CDA1 /* RegisterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterDelegate.swift; sourceTree = "<group>"; };
 		EE0AD54E29E6DB9F00C1CDA1 /* RegisterSecondInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterSecondInfoViewModel.swift; sourceTree = "<group>"; };
 		EE0AD55029E6DBB100C1CDA1 /* RegisterSecondInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterSecondInfoViewController.swift; sourceTree = "<group>"; };
 		EE0AD55429E8220300C1CDA1 /* RegisterPriorityTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPriorityTableViewCell.swift; sourceTree = "<group>"; };
@@ -2091,7 +2091,7 @@
 			children = (
 				EE642C59298FA9A000E15869 /* ZatchRegisterRequestManager.swift */,
 				EE0AD54829E542A400C1CDA1 /* Register.swift */,
-				EE0AD54A29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift */,
+				EE0AD54A29E5AAEA00C1CDA1 /* RegisterDelegate.swift */,
 			);
 			path = Register;
 			sourceTree = "<group>";
@@ -2887,7 +2887,7 @@
 				23B051BF28E20622005D08EA /* QnAViewController.swift in Sources */,
 				EE7B76D929C5F61C00942798 /* GetMyTownUseCase.swift in Sources */,
 				57D6D79528CDBC3A00F805B7 /* MeetingSheetView.swift in Sources */,
-				EE0AD54B29E5AAEA00C1CDA1 /* ZatchRegisterDelegate.swift in Sources */,
+				EE0AD54B29E5AAEA00C1CDA1 /* RegisterDelegate.swift in Sources */,
 				57D6D7A328CDC32200F805B7 /* PlaceSearchRepsonseModel.swift in Sources */,
 				57F68BAA29652ED300DB1471 /* DetailEtcBottomSheetView.swift in Sources */,
 				EE7B76C129C5E36D00942798 /* ZatchRepositoryInterface.swift in Sources */,

--- a/Zatch/AppDelegate/SceneDelegate.swift
+++ b/Zatch/AppDelegate/SceneDelegate.swift
@@ -27,7 +27,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 //        var startViewController: UIViewController
 //        startViewController = UserManager.token == nil ? UINavigationController(rootViewController: OnboardingViewController()) : TabBarController()
         
-        window?.rootViewController = UINavigationController(rootViewController: RegisterProductInfoTestViewController())
+        window?.rootViewController = UINavigationController(rootViewController: RegisterSecondInfoViewController())
 //        window?.rootViewController = TabBarController()
         window?.makeKeyAndVisible()
     }

--- a/Zatch/Global/Source/Alert/AlertInfo.swift
+++ b/Zatch/Global/Source/Alert/AlertInfo.swift
@@ -17,6 +17,7 @@ enum Alert{
     case ImageMin
     case BuyDate
     case EndDate
+    case ChangeShare
     
     //Map
     case LocationAuthority
@@ -58,6 +59,7 @@ extension Alert{
         case .ImageMin:             return AlertDescription(message: "이미지를 최소 1장 이상 첨부해주세요.")
         case .BuyDate:              return AlertDescription(message: "구매일자를 입력해주세요.")
         case .EndDate:              return AlertDescription(message: "유통기한을 입력해주세요.")
+        case .ChangeShare:          return AlertDescription(message: "받고 싶은 상품이 없는 경우 해당 재치가\n나눔으로 전환됩니다.")
             
         case .LocationAuthority:    return AlertDescription(message: "위치 권한을 허용하셔야 동네 인증이 가능합니다.")
         case .TownCertification:    return AlertDescription(message: "현 위치와 선택하신 동네가 다릅니다.")
@@ -101,7 +103,8 @@ extension Alert{
                 .QuestionTitle,
                 .QuestionContent:       return InfoAlertViewController(message: self.information.message)
             
-        case    .ChattingRoomExit,
+        case    .ChangeShare,
+                .ChattingRoomExit,
                 .UnBlock,
                 .Register,
                 .ImageDelete,

--- a/Zatch/Global/Source/Base/Cell/BaseTableViewCell.swift
+++ b/Zatch/Global/Source/Base/Cell/BaseTableViewCell.swift
@@ -19,6 +19,7 @@ class BaseTableViewCell: UITableViewCell, CellReuse {
         self.style()
         hierarchy()
         layout()
+        initialize()
     }
     
     required init?(coder: NSCoder) {
@@ -38,5 +39,7 @@ class BaseTableViewCell: UITableViewCell, CellReuse {
             make.leading.trailing.top.bottom.equalToSuperview()
         }
     }
+    
+    func initialize(){ }
     
 }

--- a/Zatch/Global/Source/Component/RadioButtonView.swift
+++ b/Zatch/Global/Source/Component/RadioButtonView.swift
@@ -14,7 +14,7 @@ extension ZatchComponent{
         var isSelected = false{
             didSet{
                 radioButton.isSelected = isSelected
-                self.tag = isSelected ? ViewTag.select : ViewTag.normal
+//                self.tag = isSelected ? ViewTag.select : ViewTag.normal
             }
         }
         

--- a/Zatch/Presentation/Cells/DetailCells/DetailImageTableViewCell.swift
+++ b/Zatch/Presentation/Cells/DetailCells/DetailImageTableViewCell.swift
@@ -30,18 +30,7 @@ class DetailImageTableViewCell: BaseTableViewCell {
         $0.currentPageIndicatorTintColor = UIColor(red: 255/255, green: 171/255, blue: 66/255, alpha: 0.6)
         $0.pageIndicatorTintColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.4)
     }
-
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-
-        initialize()
-    }
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     override func hierarchy() {
         super.hierarchy()
         baseView.addSubview(scrollView)
@@ -65,7 +54,7 @@ class DetailImageTableViewCell: BaseTableViewCell {
         }
     }
     
-    private func initialize(){
+    override func initialize(){
         scrollView.delegate = self
         addImageContentToScrollView()
         setPageControl()

--- a/Zatch/Presentation/Cells/Mypage/BlockUserTableViewCell.swift
+++ b/Zatch/Presentation/Cells/Mypage/BlockUserTableViewCell.swift
@@ -80,7 +80,7 @@ class BlockUserTableViewCell: BaseTableViewCell {
         }
     }
     
-    private func initialize(){
+    override func initialize(){
         unblockBtn.addTarget(self, action: #selector(unblockBtnDidClicked), for: .touchUpInside)
     }
     

--- a/Zatch/Presentation/Cells/Mypage/MyInfoTableViewCell.swift
+++ b/Zatch/Presentation/Cells/Mypage/MyInfoTableViewCell.swift
@@ -70,7 +70,7 @@ class MyInfoTableViewCell: BaseTableViewCell {
         }
     }
     
-    private func initialize(){
+    override func initialize(){
         goProfileButton.addTarget(self, action: #selector(goProfileButtonDidTapped), for: .touchUpInside)
     }
     

--- a/Zatch/Presentation/Cells/Mypage/MyZatchStatisticTableViewCell.swift
+++ b/Zatch/Presentation/Cells/Mypage/MyZatchStatisticTableViewCell.swift
@@ -69,7 +69,7 @@ class MyZatchStatisticTableViewCell: BaseTableViewCell {
         }
     }
     
-    private func initialize() {
+    override func initialize() {
         myZatchCountView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(myZatchCountViewDidTapped)))
         heartCountView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(heartCountViewDidTapped)))
         exchangeCountView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(exchangeCountViewDidTapped)))

--- a/Zatch/Presentation/Cells/Mypage/Setting/AlarmSettingTableViewCell.swift
+++ b/Zatch/Presentation/Cells/Mypage/Setting/AlarmSettingTableViewCell.swift
@@ -75,7 +75,7 @@ class AlarmSettingTableViewCell: BaseTableViewCell {
         }
     }
     
-    private func initialize() {
+    override func initialize() {
         alarmSwitch.addTarget(self, action: #selector(willSwitchValueChange), for: .valueChanged)
     }
     

--- a/Zatch/Presentation/Cells/Mypage/TownSettingTableViewCell.swift
+++ b/Zatch/Presentation/Cells/Mypage/TownSettingTableViewCell.swift
@@ -27,18 +27,8 @@ class TownSettingTableViewCell: BaseTableViewCell {
         $0.setTypoStyleWithSingleLine(typoStyle: .medium16)
     }
     private let borderLine = ZatchComponent.SectionDivider()
-
-    // MARK: - LifeCycles
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        initialize()
-    }
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func initialize(){
+    override func initialize(){
         townStackView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(townStackViewDidTappeed)))
     }
 

--- a/Zatch/Presentation/Cells/RegisterCells/AnyZatchSelectTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/AnyZatchSelectTableViewCell.swift
@@ -1,0 +1,43 @@
+//
+//  AnyZatchSelectTableViewCell.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/04/13.
+//
+
+import Foundation
+
+class AnyZatchSelectTableViewCell: BaseTableViewCell{
+    
+    private let radioButtonFrame = UIStackView().then{
+        $0.spacing = 16
+        $0.axis = .vertical
+    }
+    
+    private let topRadioButtonFrame = ZatchComponent.RadioButtonView().then{
+        $0.setTitle("다른 것도 괜찮아요!")
+        $0.isSelected = true
+    }
+    
+    private let belowRadioButtonFrame = ZatchComponent.RadioButtonView().then{
+        $0.setTitle("이 것만 가능해요!")
+    }
+    
+    override func hierarchy() {
+        super.hierarchy()
+        baseView.addSubview(radioButtonFrame)
+        radioButtonFrame.addArrangedSubview(topRadioButtonFrame)
+        radioButtonFrame.addArrangedSubview(belowRadioButtonFrame)
+    }
+    
+    override func layout() {
+        super.layout()
+        radioButtonFrame.snp.makeConstraints{
+            $0.top.equalToSuperview().offset(36)
+            $0.leading.equalToSuperview().offset(24)
+            $0.bottom.equalToSuperview()
+        }
+    }
+    
+    
+}

--- a/Zatch/Presentation/Cells/RegisterCells/AnyZatchSelectTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/AnyZatchSelectTableViewCell.swift
@@ -6,8 +6,20 @@
 //
 
 import Foundation
+import RxGesture
 
 class AnyZatchSelectTableViewCell: BaseTableViewCell{
+    
+    var delegate: RegisterSecondInfoDelegate!
+    
+    private lazy var selectedRadioButton: ZatchComponent.RadioButtonView = topRadioButtonFrame{
+        willSet{
+            selectedRadioButton.isSelected = false
+        }
+        didSet{
+            selectedRadioButton.isSelected = true
+        }
+    }
     
     private let radioButtonFrame = UIStackView().then{
         $0.spacing = 16
@@ -15,11 +27,13 @@ class AnyZatchSelectTableViewCell: BaseTableViewCell{
     }
     
     private let topRadioButtonFrame = ZatchComponent.RadioButtonView().then{
+        $0.tag = Register.WantZatch.anyZatch.rawValue
         $0.setTitle("다른 것도 괜찮아요!")
         $0.isSelected = true
     }
     
     private let belowRadioButtonFrame = ZatchComponent.RadioButtonView().then{
+        $0.tag = Register.WantZatch.onlyRegister.rawValue
         $0.setTitle("이 것만 가능해요!")
     }
     
@@ -39,5 +53,16 @@ class AnyZatchSelectTableViewCell: BaseTableViewCell{
         }
     }
     
+    override func initialize() {
+        topRadioButtonFrame.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(changeSelectRadioButtonElement)))
+        belowRadioButtonFrame.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(changeSelectRadioButtonElement)))
+    }
     
+    @objc private func changeSelectRadioButtonElement(recognizer: UITapGestureRecognizer){
+        if let recognizer = recognizer.view as? ZatchComponent.RadioButtonView,
+            let wantZatchType = Register.WantZatch(rawValue: recognizer.tag){
+            selectedRadioButton = recognizer
+            delegate.selectWantZatchType(wantZatchType)
+        }
+    }
 }

--- a/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductDateChoiceTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductDateChoiceTableViewCell.swift
@@ -19,7 +19,7 @@ final class ProductDateChoiceTableViewCell: BaseTableViewCell {
         checkButton.isSelected
     }
     
-    var delegate: ZatchRegisterDelegate!
+    var delegate: RegisterFirstInfoDelegate!
     
     private let backView = UIView()
     private let titleLabel = UILabel().then{

--- a/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductIsOpenTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductIsOpenTableViewCell.swift
@@ -12,7 +12,7 @@ import RxCocoa
 class ProductIsOpenTableViewCell: BaseTableViewCell, DefaultObservable {
     
     let disposeBag = DisposeBag()
-    var delegate: ZatchRegisterDelegate!
+    var delegate: RegisterFirstInfoDelegate!
     
     private lazy var selectRadioButton: ZatchComponent.FilledTag = unOpenRadioButton{
         willSet{

--- a/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductQuantityTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductQuantityTableViewCell.swift
@@ -19,6 +19,7 @@ class ProductQuantityTableViewCell: BaseTableViewCell {
     }
     
     let countTextField = UITextField().then{
+        $0.font = UIFont.pretendard(family: .Medium)
         $0.textAlignment = .center
         $0.keyboardType = .numberPad
     }
@@ -85,7 +86,7 @@ class ProductQuantityTableViewCell: BaseTableViewCell {
         
         textFieldBorderLine.snp.makeConstraints{ make in
             make.height.equalTo(1)
-            make.bottom.equalTo(countTextField)
+            make.bottom.equalTo(countTextField).offset(2)
             make.leading.trailing.equalTo(countTextField)
         }
         unitStackView.snp.makeConstraints{

--- a/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductQuantityTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/DetailInput/ProductQuantityTableViewCell.swift
@@ -11,7 +11,7 @@ class ProductQuantityTableViewCell: BaseTableViewCell {
     
     //MARK: - UIView
     
-    var delegate: ZatchRegisterDelegate!
+    var delegate: RegisterFirstInfoDelegate!
     
     private let titleLabel = UILabel().then{
         $0.text = "수량"
@@ -104,7 +104,7 @@ class ProductQuantityTableViewCell: BaseTableViewCell {
         }
     }
     
-    private func initialize(){
+    override func initialize(){
         unitStackView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(unitStackViewDidTapped)))
     }
     

--- a/Zatch/Presentation/Cells/RegisterCells/ImageAddTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/ImageAddTableViewCell.swift
@@ -39,17 +39,8 @@ class ImageAddTableViewCell: BaseTableViewCell {
         $0.setTypoStyleWithSingleLine(typoStyle: .medium14)
         $0.text = "0 / 10"
     }
-
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        initialize()
-    }
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func initialize(){
+    override func initialize(){
         imageCollectionView.delegate = self
         imageCollectionView.dataSource = self
     }

--- a/Zatch/Presentation/Cells/RegisterCells/ProductDetailInputTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/ProductDetailInputTableViewCell.swift
@@ -33,15 +33,6 @@ class ProductDetailInputTableViewCell: BaseTableViewCell {
         $0.register(cellType: ProductIsOpenTableViewCell.self)
     }
     
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        initialize()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
     override func hierarchy() {
         super.hierarchy()
         baseView.addSubview(tableView)
@@ -55,7 +46,7 @@ class ProductDetailInputTableViewCell: BaseTableViewCell {
         }
     }
     
-    private func initialize(){
+    override func initialize(){
         tableView.dataSource = self
         tableView.delegate = self
         tableView.separatorStyle = .none

--- a/Zatch/Presentation/Cells/RegisterCells/RegisterPriorityTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/RegisterPriorityTableViewCell.swift
@@ -1,0 +1,35 @@
+//
+//  RegisterPriorityTableViewCell.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/04/13.
+//
+
+import Foundation
+
+class RegisterPriorityTableViewCell: BaseTableViewCell{
+    
+    var priority: Int!{
+        didSet{
+            titleLabel.text = "\(String(priority))순위"
+        }
+    }
+    
+    private let titleLabel = UILabel().then{
+        $0.setTypoStyleWithSingleLine(typoStyle: .medium14)
+    }
+    
+    override func hierarchy() {
+        super.hierarchy()
+        baseView.addSubview(titleLabel)
+    }
+    
+    override func layout() {
+        super.layout()
+        titleLabel.snp.makeConstraints{
+            $0.top.equalToSuperview().offset(20)
+            $0.bottom.equalToSuperview().inset(10)
+            $0.leading.equalToSuperview().offset(36)
+        }
+    }
+}

--- a/Zatch/Presentation/Cells/RegisterCells/TextFieldTabeViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/TextFieldTabeViewCell.swift
@@ -30,6 +30,12 @@ class TextFieldTabeViewCell: BaseTableViewCell, DefaultObservable {
         }
     }
     
+    var textFieldDelegate: UITextFieldDelegate?{
+        didSet{
+            textField.delegate = textFieldDelegate
+        }
+    }
+    
     var textObservable: Observable<String>!{
         textField.rx.text.orEmpty.asObservable()
     }
@@ -49,15 +55,6 @@ class TextFieldTabeViewCell: BaseTableViewCell, DefaultObservable {
     }
     private let textField = UITextField().then{
         $0.font = UIFont.pretendard(family: .Medium)
-    }
-    
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        bind()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
     
     override func hierarchy(){

--- a/Zatch/Presentation/Cells/Util/Profile/ProfileTableViewCell.swift
+++ b/Zatch/Presentation/Cells/Util/Profile/ProfileTableViewCell.swift
@@ -54,15 +54,6 @@ class ProfileTableViewCell: BaseTableViewCell {
     }
     private let borderLine = ZatchComponent.SectionDivider()
 
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        initialize()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     // MARK: - Functions
     
     override func hierarchy() {
@@ -115,7 +106,7 @@ class ProfileTableViewCell: BaseTableViewCell {
         }
     }
     
-    private func initialize(){
+    override func initialize(){
         moreButton.addTarget(self, action: #selector(moreButtonDidTapped), for: .touchUpInside)
     }
     

--- a/Zatch/Presentation/Utils/Register/Register.swift
+++ b/Zatch/Presentation/Utils/Register/Register.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct Register{
+    
     @frozen
     enum ProductDate: String{
         case buy = "구매일자"
@@ -18,6 +19,12 @@ struct Register{
     enum ProductOpenState: Int{
         case open = 1
         case unopen = 2
+    }
+    
+    @frozen
+    enum WantZatch: Int{
+        case onlyRegister = 0
+        case anyZatch = 1
     }
     
     typealias DateString = (year: String, month: String, date: String)

--- a/Zatch/Presentation/Utils/Register/RegisterDelegate.swift
+++ b/Zatch/Presentation/Utils/Register/RegisterDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  ZatchRegisterDelegate.swift
+//  RegisterDelegate.swift
 //  Zatch
 //
 //  Created by 박소윤 on 2023/04/11.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol ZatchRegisterDelegate{
+protocol RegisterFirstInfoDelegate{
     func willShowUnitBottomSheet()
     func changeIsOpenState(_ state: Int)
     func dateNotConfirmed(about type: Register.ProductDate)

--- a/Zatch/Presentation/Utils/Register/RegisterDelegate.swift
+++ b/Zatch/Presentation/Utils/Register/RegisterDelegate.swift
@@ -12,3 +12,7 @@ protocol RegisterFirstInfoDelegate{
     func changeIsOpenState(_ state: Int)
     func dateNotConfirmed(about type: Register.ProductDate)
 }
+
+protocol RegisterSecondInfoDelegate{
+    func selectWantZatchType(_ type: Register.WantZatch)
+}

--- a/Zatch/Presentation/ViewControllers/Register/RegisterFirstInfoViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterFirstInfoViewController.swift
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-final class RegisterProductInfoTestViewController: BaseViewController<LeftNavigationHeaderView, ZatchRegisterFirstView>{
+final class RegisterFirstInfoViewController: BaseViewController<LeftNavigationHeaderView, ZatchRegisterFirstView>{
     
     //MARK: - Generator
     
@@ -39,7 +39,7 @@ final class RegisterProductInfoTestViewController: BaseViewController<LeftNaviga
     private let BUY_DATE_CELL_INDEX: IndexPath = [1,1]
     private let END_DATE_CELL_INDEX: IndexPath = [1,2]
     
-    private let viewModel = FirstRegisterTestViewModel()
+    private let viewModel = RegisterFirstInfoTestViewModel()
     private let categoryBottomSheet = CategorySheetViewController()
     
     //불충족 조건 파악 위한 모든 Relay에 기본 값 설정
@@ -94,7 +94,7 @@ final class RegisterProductInfoTestViewController: BaseViewController<LeftNaviga
             }).disposed(by: disposeBag)
         
         
-        let input = FirstRegisterTestViewModel.Input(nextButtonTap: mainView.nextButton.rx.tap,
+        let input = RegisterFirstInfoTestViewModel.Input(nextButtonTap: mainView.nextButton.rx.tap,
                                                      categoryId: categoryRelay.asObservable(),
                                                      count: countSubject.asObservable(),
                                                      countUnit: countUnitSubject.asObservable(),
@@ -123,7 +123,7 @@ final class RegisterProductInfoTestViewController: BaseViewController<LeftNaviga
 
 //MARK: - UITableViewDelegate
 
-extension RegisterProductInfoTestViewController: UITableViewDelegate, UITableViewDataSource{
+extension RegisterFirstInfoViewController: UITableViewDelegate, UITableViewDataSource{
     
     func numberOfSections(in tableView: UITableView) -> Int {
         2
@@ -243,7 +243,7 @@ extension RegisterProductInfoTestViewController: UITableViewDelegate, UITableVie
     }
 }
 
-extension RegisterProductInfoTestViewController: UITextFieldDelegate{
+extension RegisterFirstInfoViewController: UITextFieldDelegate{
     func textFieldDidEndEditing(_ textField: UITextField) {
         countSubject.onNext(textField.text ?? "")
     }
@@ -251,7 +251,7 @@ extension RegisterProductInfoTestViewController: UITextFieldDelegate{
 
 //MARK: - ProductRegisterDelegate
 
-extension RegisterProductInfoTestViewController: ZatchRegisterDelegate{
+extension RegisterFirstInfoViewController: ZatchRegisterDelegate{
     
     func willShowUnitBottomSheet() {
         //임시

--- a/Zatch/Presentation/ViewControllers/Register/RegisterFirstInfoViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterFirstInfoViewController.swift
@@ -251,7 +251,7 @@ extension RegisterFirstInfoViewController: UITextFieldDelegate{
 
 //MARK: - ProductRegisterDelegate
 
-extension RegisterFirstInfoViewController: ZatchRegisterDelegate{
+extension RegisterFirstInfoViewController: RegisterFirstInfoDelegate{
     
     func willShowUnitBottomSheet() {
         //임시

--- a/Zatch/Presentation/ViewControllers/Register/RegisterProductInfoTestViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterProductInfoTestViewController.swift
@@ -183,6 +183,7 @@ extension RegisterProductInfoTestViewController: UITableViewDelegate, UITableVie
     
     private func getProductQuantityTableViewCell(indexPath: IndexPath) -> BaseTableViewCell{
         return mainView.backTableView.dequeueReusableCell(for: indexPath, cellType: ProductQuantityTableViewCell.self).then{
+            $0.delegate = self
             $0.countTextField.delegate = self
         }
     }

--- a/Zatch/Presentation/ViewControllers/Register/RegisterSecondInfoViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterSecondInfoViewController.swift
@@ -1,0 +1,104 @@
+//
+//  RegisterSecondInfoViewController.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/04/12.
+//
+
+import Foundation
+
+class RegisterSecondInfoViewController: BaseViewController<LeftNavigationEtcButtonHeaderView,ZatchRegisterSecondView>{
+    
+//    private let firstInformation: RegisterFirstInformationDTO
+//
+//    init(firstInformation: RegisterFirstInformationDTO){
+//        self.firstInformation = firstInformation
+//        super.init(headerView: LeftNavigationEtcButtonHeaderView(title: "재치 등록하기", etcButton: Image.exit),
+//                   mainView: ZatchRegisterSecondView())
+//    }
+    
+    init(){
+        super.init(headerView: LeftNavigationEtcButtonHeaderView(title: "재치 등록하기", etcButton: Image.exit),
+                   mainView: ZatchRegisterSecondView())
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(headerView: LeftNavigationEtcButtonHeaderView(title: "재치 등록하기", etcButton: Image.exit),
+                   mainView: ZatchRegisterSecondView())
+    }
+    
+    private var isCategoryFieldOpen = [true, false, false]{
+        didSet{
+            mainView.tableView.reloadData()
+        }
+    }
+    
+    override func initialize() {
+        mainView.tableView.initializeDelegate(self)
+        setButtonTarget()
+    }
+    
+    private func setButtonTarget(){
+        headerView.etcButton.addTarget(self, action: #selector(exitBtnDidClicked), for: .touchUpInside)
+        mainView.shareBtn.addTarget(self, action: #selector(shareBtnDidClicked), for: .touchUpInside)
+        mainView.nextBtn.addTarget(self, action: #selector(nextBtnDidClicked), for: .touchUpInside)
+    }
+    
+    @objc private func shareBtnDidClicked(){
+        let vc = CheckShareRegisterViewController()
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    
+    @objc private func nextBtnDidClicked(){
+        let vc = CheckExchangeRegisterViewController()
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    
+    @objc private func exitBtnDidClicked(){
+        navigationController?.popToRootViewController(animated: true)
+    }
+}
+
+extension RegisterSecondInfoViewController: UITableViewDelegate, UITableViewDataSource{
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        4
+    }
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return section == 3 ? 1 : section == 0 || isCategoryFieldOpen[section] ? 3 : 2
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if(indexPath.section == 3){
+            return getAnyZatchSelectTableViewCell(indexPath: indexPath)
+        }
+        switch indexPath.row{
+        case 0:     return getPriorityTableViewCell(indexPath: indexPath)
+        case 1:     return getCategorySelectTableViewCell(indexPath: indexPath)
+        case 2:     return getProductNameTextFieldTableViewCell(indexPath: indexPath)
+        default:    fatalError("재치 등록 받고 싶은 물건 TableView indexPath 오류")
+        }
+    }
+    
+    private func getPriorityTableViewCell(indexPath: IndexPath) -> BaseTableViewCell{
+        mainView.tableView.dequeueReusableCell(for: indexPath, cellType: RegisterPriorityTableViewCell.self).then{
+            $0.priority = indexPath.section + 1
+        }
+    }
+    
+    private func getCategorySelectTableViewCell(indexPath: IndexPath) -> BaseTableViewCell{
+        mainView.tableView.dequeueReusableCell(for: indexPath, cellType: RegisterCategorySelectTableViewCell.self)
+    }
+    
+    private func getProductNameTextFieldTableViewCell(indexPath: IndexPath) -> BaseTableViewCell{
+        mainView.tableView.dequeueReusableCell(for: indexPath, cellType: TextFieldTabeViewCell.self).then{
+            $0.informationTypeTest = .product
+        }
+    }
+    
+    private func getAnyZatchSelectTableViewCell(indexPath: IndexPath) -> BaseTableViewCell {
+        mainView.tableView.dequeueReusableCell(for: indexPath, cellType: AnyZatchSelectTableViewCell.self)
+    }
+    
+    
+}

--- a/Zatch/Presentation/ViewControllers/Register/RegisterSecondInfoViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterSecondInfoViewController.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
 
 class RegisterSecondInfoViewController: BaseViewController<LeftNavigationEtcButtonHeaderView,ZatchRegisterSecondView>{
     
@@ -27,11 +29,18 @@ class RegisterSecondInfoViewController: BaseViewController<LeftNavigationEtcButt
                    mainView: ZatchRegisterSecondView())
     }
     
-    private var isCategoryFieldOpen = [true, false, false]{
-        didSet{
-            mainView.tableView.reloadData()
-        }
-    }
+    private var isCategoryFieldOpen = [true, false, false]
+
+    private let CATEGORY_ROW = 1
+    private let categoryBottomSheet = CategorySheetViewController()
+    
+    private let firstCategorySubject = BehaviorRelay<Int?>(value: nil)
+    private let firstProductNameSubject = BehaviorSubject<String>(value: "")
+    private let secondCategorySubject = BehaviorRelay<Int?>(value: nil)
+    private let secondProductNameSubject = BehaviorSubject<String>(value: "")
+    private let thirdCategorySubject = BehaviorRelay<Int?>(value: nil)
+    private let thirdProductNameSubject = BehaviorSubject<String>(value: "")
+    private let wantProductTypeSubject = BehaviorSubject<Register.WantZatch>(value: .anyZatch)
     
     override func initialize() {
         mainView.tableView.initializeDelegate(self)
@@ -42,6 +51,67 @@ class RegisterSecondInfoViewController: BaseViewController<LeftNavigationEtcButt
         headerView.etcButton.addTarget(self, action: #selector(exitBtnDidClicked), for: .touchUpInside)
         mainView.shareBtn.addTarget(self, action: #selector(shareBtnDidClicked), for: .touchUpInside)
         mainView.nextBtn.addTarget(self, action: #selector(nextBtnDidClicked), for: .touchUpInside)
+    }
+    
+    override func bind() {
+        
+        firstProductNameSubject.subscribe(onNext: {
+            print("first",$0)
+        })
+        
+        secondCategorySubject
+            .skip(1)
+            .first()
+            .subscribe{ [weak self] _ in
+                self?.reloadSection(1)
+            }.disposed(by: disposeBag)
+        
+        thirdCategorySubject
+            .skip(1)
+            .first()
+            .subscribe{ [weak self] _ in
+                self?.reloadSection(2)
+            }.disposed(by: disposeBag)
+        
+        firstCategorySubject
+            .compactMap{
+                $0
+            }.subscribe{ [weak self] in
+                self?.bindingCategoryCell(section: 0, categoryId: $0)
+            }.disposed(by: disposeBag)
+        
+        secondCategorySubject
+            .compactMap{
+                $0
+            }.subscribe{ [weak self] in
+                self?.bindingCategoryCell(section: 1, categoryId: $0)
+            }.disposed(by: disposeBag)
+        
+        thirdCategorySubject
+            .compactMap{
+                $0
+            }.subscribe{ [weak self] in
+                self?.bindingCategoryCell(section: 2, categoryId: $0)
+            }.disposed(by: disposeBag)
+    }
+    
+    private func reloadSection(_ section: Int){
+        defer{
+            if(isCategoryFieldOpen.allSatisfy{ $0 }){
+                mainView.tableView.isScrollEnabled = true
+            }
+        }
+        isCategoryFieldOpen[section] = true
+        mainView.tableView.reloadSections(IndexSet(integer: section), with: .none)
+        mainView.tableView.scrollToRow(at: [section,2], at: .bottom, animated: true)
+    }
+    
+    private func bindingCategoryCell(section: Int, categoryId: Int){
+        mainView.tableView
+            .cellForRow(at: [section, CATEGORY_ROW], cellType: RegisterCategorySelectTableViewCell.self)
+            .do{
+                $0.setCategoryTitle(id: categoryId)
+            }
     }
     
     @objc private func shareBtnDidClicked(){
@@ -93,11 +163,55 @@ extension RegisterSecondInfoViewController: UITableViewDelegate, UITableViewData
     private func getProductNameTextFieldTableViewCell(indexPath: IndexPath) -> BaseTableViewCell{
         mainView.tableView.dequeueReusableCell(for: indexPath, cellType: TextFieldTabeViewCell.self).then{
             $0.informationTypeTest = .product
+            $0.textObservable
+                .subscribe(onNext: {
+                    self.subscribeProductName($0, section: indexPath.section)
+                }).disposed(by: disposeBag)
+        }
+    }
+    
+    private func subscribeProductName(_ value: String, section: Int){
+        switch section{
+        case 0:         self.firstProductNameSubject.onNext(value)
+        case 1:         self.secondProductNameSubject.onNext(value)
+        case 2:         self.thirdProductNameSubject.onNext(value)
+        default:        return
         }
     }
     
     private func getAnyZatchSelectTableViewCell(indexPath: IndexPath) -> BaseTableViewCell {
-        mainView.tableView.dequeueReusableCell(for: indexPath, cellType: AnyZatchSelectTableViewCell.self)
+        mainView.tableView.dequeueReusableCell(for: indexPath, cellType: AnyZatchSelectTableViewCell.self).then{
+            $0.delegate = self
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if(indexPath.row == 1){
+            willShowCategoryBottomSheet(section: indexPath.section)
+        }
+    }
+    
+    private func willShowCategoryBottomSheet(section: Int){
+        categoryBottomSheet.show(in: self)
+        categoryBottomSheet.completion = { categoryId in
+            self.getCategorySubject(section).accept(categoryId)
+        }
+    }
+    
+    private func getCategorySubject(_ section: Int) -> BehaviorRelay<Int?>{
+        switch section{
+        case 0:     return firstCategorySubject
+        case 1:     return secondCategorySubject
+        case 2:     return thirdCategorySubject
+        default:    fatalError("section value range error")
+        }
+    }
+}
+
+extension RegisterSecondInfoViewController: RegisterSecondInfoDelegate{
+    
+    func selectWantZatchType(_ type: Register.WantZatch) {
+        wantProductTypeSubject.onNext(type)
     }
     
     

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/ZatchRegisterSecondViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/ZatchRegisterSecondViewController.swift
@@ -50,17 +50,17 @@ class ZatchRegisterSecondViewController: BaseViewController<LeftNavigationEtcBut
     }
     
     override func bind() {
-        mainView.topRadioButtonFrame.rx.tapGesture()
-            .when(.recognized)
-            .bind(onNext: { [weak self] in
-                self?.radioButtonDidSelected($0)
-            }).disposed(by: disposeBag)
-        
-        mainView.belowRadioButtonFrame.rx.tapGesture()
-            .when(.recognized)
-            .bind(onNext: { [weak self] in
-                self?.radioButtonDidSelected($0)
-            }).disposed(by: disposeBag)
+//        mainView.topRadioButtonFrame.rx.tapGesture()
+//            .when(.recognized)
+//            .bind(onNext: { [weak self] in
+//                self?.radioButtonDidSelected($0)
+//            }).disposed(by: disposeBag)
+//
+//        mainView.belowRadioButtonFrame.rx.tapGesture()
+//            .when(.recognized)
+//            .bind(onNext: { [weak self] in
+//                self?.radioButtonDidSelected($0)
+//            }).disposed(by: disposeBag)
     }
     
     //MARK: - Action

--- a/Zatch/Presentation/ViewModels/Register/RegisterFirstInfoTestViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Register/RegisterFirstInfoTestViewModel.swift
@@ -19,7 +19,7 @@ struct RegisterFirstInformationDTO{
     let isOpen: Int
 }
 
-final class FirstRegisterTestViewModel: BaseViewModel{
+final class RegisterFirstInfoTestViewModel: BaseViewModel{
     
     var productName: Observable<String>!
     
@@ -114,5 +114,5 @@ final class FirstRegisterTestViewModel: BaseViewModel{
     }
 }
 
-extension FirstRegisterTestViewModel{
+extension RegisterFirstInfoTestViewModel{
 }

--- a/Zatch/Presentation/ViewModels/Register/RegisterSecondInfoViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Register/RegisterSecondInfoViewModel.swift
@@ -1,0 +1,112 @@
+//
+//  RegisterSecondInfoViewModel.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/04/12.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+struct RegisterSecondInformationDTO{
+    let firstPriorityCategory: Int?
+    let firstProductName: String?
+    let secondPriorityCategory: Int?
+    let secondProductName: String?
+    let thirdPriorityCategory: Int?
+    let thirdProductName: String?
+    let wantProductType: Int
+    let isFree: Bool
+}
+
+class RegisterSecondInfoViewModel: BaseViewModel{
+    
+    private typealias RequestObservableType = (firstCategory: Int?,
+                                               firstProductName: String,
+                                               secondCategory: Int?,
+                                               secondProductName: String,
+                                               thirdCategory: Int?,
+                                               thirdProductName: String,
+                                               wantType: Register.WantZatch)
+    
+    struct Input{
+        let firstPriorityCategory: Observable<Int?>
+        let firstProductName: Observable<String>
+        let secondPriorityCategory: Observable<Int?>
+        let secondProductName: Observable<String>
+        let thirdPriorityCategory: Observable<Int?>
+        let thirdProductName: Observable<String>
+        let wantProductType: Observable<Register.WantZatch>
+        let shareButtonTap: ControlEvent<Void>
+        let nextButtonTap: ControlEvent<Void>
+    }
+    
+    struct Output{
+        let productsInputEmpty: Observable<RegisterSecondInformationDTO>
+        let moveShare: Observable<RegisterSecondInformationDTO>
+        let moveExchange: Observable<RegisterSecondInformationDTO>
+    }
+    
+    func transform(_ input: Input) -> Output {
+        
+        let requestObservable = Observable.combineLatest(input.firstPriorityCategory,
+                                                         input.firstProductName,
+                                                         input.secondPriorityCategory,
+                                                         input.secondProductName,
+                                                         input.thirdPriorityCategory,
+                                                         input.thirdProductName,
+                                                         input.wantProductType)
+        
+        let moveShare = input.shareButtonTap
+            .withLatestFrom(requestObservable)
+            .map{
+                self.setRegisterSecondInfoDTO($0, isFree: true)
+            }
+        
+        let checkValidation = input.nextButtonTap
+            .withLatestFrom(requestObservable)
+            .map{
+                self.checkExchangeValidation($0)
+            }.share()
+        
+        let productInputEmpty = checkValidation
+            .filter{ !$0 }
+            .withLatestFrom(requestObservable)
+            .map{
+                self.setRegisterSecondInfoDTO($0, isFree: true)
+            }
+        
+        let moveExchange = checkValidation
+            .filter{ $0 }
+            .withLatestFrom(requestObservable)
+            .map{
+                self.setRegisterSecondInfoDTO($0, isFree: false)
+            }
+        
+        return Output(productsInputEmpty: productInputEmpty,
+                      moveShare: moveShare,
+                      moveExchange: moveExchange)
+    }
+    
+    private func setRegisterSecondInfoDTO(_ observable: RequestObservableType, isFree: Bool) -> RegisterSecondInformationDTO{
+        return RegisterSecondInformationDTO(firstPriorityCategory: observable.firstCategory,
+                                            firstProductName: observable.firstProductName,
+                                            secondPriorityCategory: observable.secondCategory,
+                                            secondProductName: observable.secondProductName,
+                                            thirdPriorityCategory: observable.thirdCategory,
+                                            thirdProductName: observable.thirdProductName,
+                                            wantProductType: observable.wantType.rawValue,
+                                            isFree: isFree)
+    }
+    
+    private func checkExchangeValidation(_ observable: RequestObservableType) -> Bool{
+        
+        let category = [observable.firstCategory, observable.secondCategory, observable.thirdCategory]
+        let productName = [observable.firstProductName, observable.secondProductName, observable.thirdProductName]
+        let zip = zip(category, productName)
+        
+        return zip.contains{ $0.0 != nil && !$0.1.isEmpty }
+    }
+    
+}

--- a/Zatch/Presentation/Views/RegisterView/ZatchRegisterSecondView.swift
+++ b/Zatch/Presentation/Views/RegisterView/ZatchRegisterSecondView.swift
@@ -11,29 +11,19 @@ class ZatchRegisterSecondView: BaseView {
     
     //MARK: - UI
     
-    let topTitleView = TopTitleView(title: "받고 싶은\n물건이 있나요?")
+    private let topTitleView = TopTitleView(title: "받고 싶은\n물건이 있나요?")
     
-    var tableView = UITableView().then{
+    let tableView = UITableView().then{
         $0.showsVerticalScrollIndicator = false
-        
-        $0.register(cellType: RegisterCategorySelectWithPriorityTableViewCell.self)
+        $0.isScrollEnabled = Device.isSmallDevice ? true : false
+        $0.contentInset = UIEdgeInsets(top: -10, left: 0, bottom: 0, right: 0)
+        $0.register(cellType: RegisterPriorityTableViewCell.self)
+        $0.register(cellType: RegisterCategorySelectTableViewCell.self)
         $0.register(cellType: TextFieldTabeViewCell.self)
+        $0.register(cellType: AnyZatchSelectTableViewCell.self)
     }
     
-    let radioButtonFrame = UIStackView().then{
-        $0.spacing = 16
-        $0.axis = .vertical
-    }
-    
-    let topRadioButtonFrame = ZatchComponent.RadioButtonView().then{
-        $0.setTitle("다른 것도 괜찮아요!")
-        $0.isSelected = true
-    }
-    let belowRadioButtonFrame = ZatchComponent.RadioButtonView().then{
-        $0.setTitle("이 것만 가능해요!")
-    }
-    
-    let btnFrame = UIStackView().then{
+    private let btnFrame = UIStackView().then{
         $0.spacing = 10
         $0.axis = .horizontal
     }
@@ -44,28 +34,11 @@ class ZatchRegisterSecondView: BaseView {
     
     lazy var nextBtn = Purple36Button(title: "다음 단계로")
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        initialize()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func initialize() {
-        topRadioButtonFrame.isSelected = true
-    }
-
     override func hierarchy() {
         
-        self.addSubview(topTitleView)
-        self.addSubview(tableView)
-        self.addSubview(radioButtonFrame)
-        self.addSubview(btnFrame)
-        
-        self.radioButtonFrame.addArrangedSubview(topRadioButtonFrame)
-        self.radioButtonFrame.addArrangedSubview(belowRadioButtonFrame)
+        addSubview(topTitleView)
+        addSubview(tableView)
+        addSubview(btnFrame)
         
         btnFrame.addArrangedSubview(shareBtn)
         btnFrame.addArrangedSubview(nextBtn)
@@ -73,30 +46,25 @@ class ZatchRegisterSecondView: BaseView {
     
     override func layout() {
         
-        topTitleView.snp.makeConstraints{ make in
-            make.top.equalToSuperview()
-            make.leading.trailing.equalToSuperview()
+        topTitleView.snp.makeConstraints{
+            $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
         }
         
-        tableView.snp.makeConstraints{ make in
-            make.top.equalTo(topTitleView.snp.bottom).offset(-11)
-            make.leading.trailing.equalToSuperview()
+        tableView.snp.makeConstraints{
+            $0.top.equalTo(topTitleView.snp.bottom).offset(-11)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(btnFrame).inset(10)
         }
         
-        radioButtonFrame.snp.makeConstraints{ make in
-            make.top.equalTo(tableView.snp.bottom).offset(36)
-            make.leading.equalToSuperview().offset(24)
+        btnFrame.snp.makeConstraints{
+            $0.leading.equalToSuperview().offset(25)
+            $0.trailing.equalToSuperview().offset(-15)
+            $0.bottom.equalToSuperview().offset(-48)
         }
         
-        btnFrame.snp.makeConstraints{ make in
-            make.leading.equalToSuperview().offset(25)
-            make.trailing.equalToSuperview().offset(-15)
-            make.bottom.equalToSuperview().offset(-48)
-            make.top.equalTo(radioButtonFrame.snp.bottom).offset(68) //68
-        }
-        
-        nextBtn.snp.makeConstraints{ make in
-            make.width.equalTo(shareBtn)
+        nextBtn.snp.makeConstraints{
+            $0.width.equalTo(shareBtn)
         }
     }
 }

--- a/Zatch/Presentation/Views/RegisterView/ZatchRegisterSecondView.swift
+++ b/Zatch/Presentation/Views/RegisterView/ZatchRegisterSecondView.swift
@@ -16,7 +16,7 @@ class ZatchRegisterSecondView: BaseView {
     let tableView = UITableView().then{
         $0.showsVerticalScrollIndicator = false
         $0.isScrollEnabled = Device.isSmallDevice ? true : false
-        $0.contentInset = UIEdgeInsets(top: -10, left: 0, bottom: 0, right: 0)
+        $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 20, right: 0)
         $0.register(cellType: RegisterPriorityTableViewCell.self)
         $0.register(cellType: RegisterCategorySelectTableViewCell.self)
         $0.register(cellType: TextFieldTabeViewCell.self)
@@ -52,9 +52,9 @@ class ZatchRegisterSecondView: BaseView {
         }
         
         tableView.snp.makeConstraints{
-            $0.top.equalTo(topTitleView.snp.bottom).offset(-11)
+            $0.top.equalTo(topTitleView.snp.bottom).offset(-10)
             $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(btnFrame).inset(10)
+            $0.bottom.equalTo(btnFrame.snp.top).offset(-10)
         }
         
         btnFrame.snp.makeConstraints{


### PR DESCRIPTION
## What is this PR? 🔍
재치 등록 2번째 프로세스(받고 싶은 물건 입력) ViewModel 적용 리팩토링 완료

## Key Changes 🔑
### 1. View 리팩토링
+ 기존 받고 싶은 물건 유형(우선순위 내용만 가능/이외에도 상관없음) 선택을 View에 구현했었습니다. 
+ UI 상 어색한 느낌이 들어 TableViewCell로 변경했습니다. 
+ 또한 우선순위 + 카테고리 선택을 Cell 하나로 묶어 load을 진행했었는데, 우선순위 타이틀/카테고리 선택 Cell을 따로 분리했습니다. 

### 2. BaseTableViewCell 템플릿 메서드 추가
+ 기존 style, hierarchy, layout 3가지를 템플릿 메서드로 추가해놨었습니다. 
+ 버튼에 target 설정 등 TableViewCell 내에서도 초기화 관련 코드 작성이 많다고 판단하여 initialize 메서드를 추가했습니다. 

### 3. 재치 등록 두 번째 프로세스인 받고 싶은 물건 입력 ViewModel 활용 리팩토링 완료

## Related Issues ⛱
#218
