### PR TITLE
Refactor/#218-#222: 재치 등록 점검 RxSwift 활용 리팩토링 및 나눔/교환 공통 데이터 UI 바인딩 구현

### DIFF
--- a/Zatch/AppDelegate/SceneDelegate.swift
+++ b/Zatch/AppDelegate/SceneDelegate.swift
@@ -27,7 +27,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 //        var startViewController: UIViewController
 //        startViewController = UserManager.token == nil ? UINavigationController(rootViewController: OnboardingViewController()) : TabBarController()
         
-        window?.rootViewController = UINavigationController(rootViewController: RegisterSecondInfoViewController())
+        window?.rootViewController = UINavigationController(rootViewController: RegisterFirstInfoViewController())
 //        window?.rootViewController = TabBarController()
         window?.makeKeyAndVisible()
     }

--- a/Zatch/Global/Resource/Extenstion/String.swift
+++ b/Zatch/Global/Resource/Extenstion/String.swift
@@ -8,6 +8,11 @@
 import Foundation
 
 extension String{
+    
+    var dateFormat: String{
+        Int(self)! < 10 ? "0\(self)" : self
+    }
+    
     func returnEndCharacter() -> Character{
         return self[self.index(before: self.endIndex)]
     }

--- a/Zatch/Global/Source/Alert/AlertInfo.swift
+++ b/Zatch/Global/Source/Alert/AlertInfo.swift
@@ -86,7 +86,8 @@ extension Alert{
         }
     }
     
-    func generateAlert() -> AlertViewController{
+    @discardableResult
+    func show(in viewController: UIViewController) -> AlertViewController{
         
         switch self{
         case    .ImageMax,
@@ -94,14 +95,14 @@ extension Alert{
                 .ProductName,
                 .ImageMin,
                 .BuyDate,
-                .EndDate:               return BasicAlertViewController(message: self.information.message)
+                .EndDate:               return BasicAlertViewController(message: self.information.message).show(in: viewController)
             
         case    .LocationAuthority,
                 .TownCertification,
                 .AlarmInfo,
                 .QuestionCategory,
                 .QuestionTitle,
-                .QuestionContent:       return InfoAlertViewController(message: self.information.message)
+                .QuestionContent:       return InfoAlertViewController(message: self.information.message).show(in: viewController)
             
         case    .ChangeShare,
                 .ChattingRoomExit,
@@ -113,7 +114,7 @@ extension Alert{
                 .Block,
                 .Logout:                return CancelAlertViewController(message: self.information.message,
                                                                          confirmTitle: self.information.confirmTitle,
-                                                                         cancelTitle: self.information.cancelTitle)
+                                                                         cancelTitle: self.information.cancelTitle).show(in: viewController)
         }
     }
 }

--- a/Zatch/Presentation/Cells/ChattingCells/ChattingListTableViewCell.swift
+++ b/Zatch/Presentation/Cells/ChattingCells/ChattingListTableViewCell.swift
@@ -117,7 +117,7 @@ class ChattingListTableViewCell: BaseTableViewCell {
     
     @objc func deleteBtnDidClicked(){
         
-        let alert = Alert.ChattingRoomExit.generateAlert().show(in: self.navigationController)
+        let alert = Alert.ChattingRoomExit.show(in: self.navigationController)
         
         alert.completion = {
                 //TODO: - 채팅방 삭제 API 연결 -> VC에서 데이터 삭제 및 테이블 뷰 reload

--- a/Zatch/Presentation/Cells/RegisterCells/ImageAddTableViewCell.swift
+++ b/Zatch/Presentation/Cells/RegisterCells/ImageAddTableViewCell.swift
@@ -133,7 +133,7 @@ extension ImageAddTableViewCell : UICollectionViewDelegate, UICollectionViewData
                 self.navigationController?.present(alert, animated: true, completion: nil)
                 
             }else{
-                _ = Alert.ImageMax.generateAlert().show(in: self.navigationController)
+                _ = Alert.ImageMax.show(in: self.navigationController)
             }
         }else{
 

--- a/Zatch/Presentation/Utils/Map/MapViewController.swift
+++ b/Zatch/Presentation/Utils/Map/MapViewController.swift
@@ -98,7 +98,7 @@ class MapViewController: UIViewController{
     }
     
     private func willShowRestrictedServiceAlert(){
-        Alert.LocationAuthority.generateAlert().show(in: self).then{
+        Alert.LocationAuthority.show(in: self).then{
             $0.completion = { [weak self] in
                 self?.navigationController?.popViewController(animated: true)
             }

--- a/Zatch/Presentation/ViewControllers/Chatting/Appointment/MakeMeetingSheetViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Chatting/Appointment/MakeMeetingSheetViewController.swift
@@ -73,7 +73,7 @@ class MakeMeetingSheetViewController: BaseBottomSheetViewController<Void> {
     @objc func alarmSwitchWillChange(_ sender: UISwitch){
     
         if(sender.isOn){
-            _ = Alert.AlarmInfo.generateAlert().show(in: self)
+            _ = Alert.AlarmInfo.show(in: self)
         }
     }
 }

--- a/Zatch/Presentation/ViewControllers/Chatting/ChattingRoomViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Chatting/ChattingRoomViewController.swift
@@ -172,7 +172,7 @@ class ChattingRoomViewController: BaseViewController<ChattingRoomHeaderView, Cha
         
         sideMenuViewController?.dismiss(animated: true, completion: {
 
-            let alert = Alert.ChattingRoomExit.generateAlert().show(in: self)
+            let alert = Alert.ChattingRoomExit.show(in: self)
             
             alert.completion = {
                 self.navigationController?.popViewController(animated: true)
@@ -186,7 +186,7 @@ class ChattingRoomViewController: BaseViewController<ChattingRoomHeaderView, Cha
         
         guard let bottomSheet = memberBlockBottomSheet else { return }
         
-        let alert = Alert.Block(user: "쑤야").generateAlert().show(in: bottomSheet)
+        let alert = Alert.Block(user: "쑤야").show(in: bottomSheet)
         
         alert.completion = {
             print("차단 완료")

--- a/Zatch/Presentation/ViewControllers/Mypage/BlockUserViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Mypage/BlockUserViewController.swift
@@ -38,7 +38,7 @@ class BlockUserViewController: BaseViewController<CenterNavigationHeaderView, Bl
 
 extension BlockUserViewController: BlockUserDelegate{
     func willBlockUser(){
-        Alert.UnBlock.generateAlert().show(in: self).do{
+        Alert.UnBlock.show(in: self).do{
             $0.completion = {
                 print("block success")
             }

--- a/Zatch/Presentation/ViewControllers/Mypage/SettingViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Mypage/SettingViewController.swift
@@ -126,7 +126,7 @@ extension SettingViewController: UITableViewDataSource, UITableViewDelegate{
             let blockVC = BlockUserViewController()
             self.navigationController?.pushViewController(blockVC, animated: true)
         case [2,2]:
-            let alert = Alert.Logout.generateAlert().show(in: self)
+            let alert = Alert.Logout.show(in: self)
             alert.completion = {
                 print("로그아웃 버튼 클릭")
             }

--- a/Zatch/Presentation/ViewControllers/QnA/RegisterQuestionViewController.swift
+++ b/Zatch/Presentation/ViewControllers/QnA/RegisterQuestionViewController.swift
@@ -62,18 +62,18 @@ class RegisterQuestionViewController: UIViewController {
         // 예외처리
         // 카테고리 선택 안 했을 때
         if !isCategorySelected {
-            _ = Alert.QuestionCategory.generateAlert().show(in: self)
+            _ = Alert.QuestionCategory.show(in: self)
         }
         // 제목을 입력하지 않았을 때
         if self.questionTitle == nil {
-            _ = Alert.QuestionTitle.generateAlert().show(in: self)
+            _ = Alert.QuestionTitle.show(in: self)
         }
         // 내용을 입력하지 않았을 때
         if self.questionContent == nil {
-            _ = Alert.QuestionContent.generateAlert().show(in: self)
+            _ = Alert.QuestionContent.show(in: self)
         }
         if isCategorySelected && self.questionTitle != nil && self.questionContent != nil {
-            let alert = Alert.QuestionRegister.generateAlert().show(in: self)
+            let alert = Alert.QuestionRegister.show(in: self)
             alert.completion = {
                 print("등록 clicked!")
             }

--- a/Zatch/Presentation/ViewControllers/Register/RegisterFirstInfoViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterFirstInfoViewController.swift
@@ -117,7 +117,8 @@ final class RegisterFirstInfoViewController: BaseViewController<LeftNavigationHe
     }
     
     private func moveNextViewController(zatchDTO: RegisterFirstInformationDTO){
-        print(zatchDTO)
+        let vc = RegisterSecondInfoViewController(firstInformation: zatchDTO)
+        navigationController?.pushViewController(vc, animated: true)
     }
 }
 

--- a/Zatch/Presentation/ViewControllers/Register/RegisterFirstInfoViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterFirstInfoViewController.swift
@@ -112,7 +112,7 @@ final class RegisterFirstInfoViewController: BaseViewController<LeftNavigationHe
         
         output.dissatisfactionType
             .drive(onNext: {
-                $0.generateAlert().show(in: self)
+                $0.show(in: self)
             }).disposed(by: disposeBag)
     }
     

--- a/Zatch/Presentation/ViewControllers/Register/RegisterSecondInfoViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterSecondInfoViewController.swift
@@ -11,22 +11,16 @@ import RxCocoa
 
 class RegisterSecondInfoViewController: BaseViewController<LeftNavigationEtcButtonHeaderView,ZatchRegisterSecondView>{
     
-//    private let firstInformation: RegisterFirstInformationDTO
-//
-//    init(firstInformation: RegisterFirstInformationDTO){
-//        self.firstInformation = firstInformation
-//        super.init(headerView: LeftNavigationEtcButtonHeaderView(title: "재치 등록하기", etcButton: Image.exit),
-//                   mainView: ZatchRegisterSecondView())
-//    }
-    
-    init(){
+    private let myProductInfo: RegisterFirstInformationDTO
+
+    init(firstInformation: RegisterFirstInformationDTO){
+        self.myProductInfo = firstInformation
         super.init(headerView: LeftNavigationEtcButtonHeaderView(title: "재치 등록하기", etcButton: Image.exit),
                    mainView: ZatchRegisterSecondView())
     }
     
     required init?(coder: NSCoder) {
-        super.init(headerView: LeftNavigationEtcButtonHeaderView(title: "재치 등록하기", etcButton: Image.exit),
-                   mainView: ZatchRegisterSecondView())
+        fatalError("init(coder:) has not been implemented")
     }
     
     private var isCategoryFieldOpen = [true, false, false]
@@ -56,14 +50,14 @@ class RegisterSecondInfoViewController: BaseViewController<LeftNavigationEtcButt
     override func bind() {
         
         secondCategorySubject
-            .skip(1)
+            .skip(1) //기본 값 nil skip
             .first()
             .subscribe{ [weak self] _ in
                 self?.reloadSection(1)
             }.disposed(by: disposeBag)
         
         thirdCategorySubject
-            .skip(1)
+            .skip(1) //기본 값 nil skip
             .first()
             .subscribe{ [weak self] _ in
                 self?.reloadSection(2)
@@ -140,13 +134,13 @@ class RegisterSecondInfoViewController: BaseViewController<LeftNavigationEtcButt
             }
     }
     
-    private func moveShareViewController(with info: RegisterSecondInformationDTO){
-        let vc = CheckShareRegisterViewController()
+    private func moveShareViewController(with wantProductInfo: RegisterSecondInformationDTO){
+        let vc = CheckShareRegisterViewController(myProductInfo: myProductInfo, wantProductInfo: wantProductInfo)
         navigationController?.pushViewController(vc, animated: true)
     }
     
-    private func moveExchangeViewController(with info: RegisterSecondInformationDTO){
-        let vc = CheckExchangeRegisterViewController()
+    private func moveExchangeViewController(with wantProductInfo: RegisterSecondInformationDTO){
+        let vc = CheckExchangeRegisterViewController(myProductInfo: myProductInfo, wantProductInfo: wantProductInfo)
         navigationController?.pushViewController(vc, animated: true)
     }
     

--- a/Zatch/Presentation/ViewControllers/Register/RegisterSecondInfoViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/RegisterSecondInfoViewController.swift
@@ -104,7 +104,7 @@ class RegisterSecondInfoViewController: BaseViewController<LeftNavigationEtcButt
         
         output.productsInputEmpty
             .subscribe(onNext: { secondInfo in
-                let alert = Alert.ChangeShare.generateAlert().show(in: self)
+                let alert = Alert.ChangeShare.show(in: self)
                 alert.completion = {
                     self.moveShareViewController(with: secondInfo)
                 }

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/CheckExchangeRegisterViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/CheckExchangeRegisterViewController.swift
@@ -8,14 +8,17 @@
 import UIKit
 
 class CheckExchangeRegisterViewController: CheckRegisterViewController {
-
-    init(){
-        super.init(infoView: CheckExchangeRegisterInfoView())
+    
+    private let wantProductInfo: RegisterSecondInformationDTO
+    
+    init(myProductInfo: RegisterFirstInformationDTO, wantProductInfo: RegisterSecondInformationDTO){
+        self.wantProductInfo = wantProductInfo
+        super.init(myProductInfo: myProductInfo,
+                   infoView: CheckExchangeRegisterInfoView())
     }
     
     required init?(coder: NSCoder) {
-        super.init(infoView: CheckExchangeRegisterInfoView())
+        fatalError("init(coder:) has not been implemented")
     }
-    
 }
 

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
@@ -63,6 +63,59 @@ class CheckRegisterViewController: BaseViewController<LeftNavigationEtcButtonHea
             $0.openFrame.setInfo(value: Register.ProductOpenState(rawValue: myProductInfo.isOpen)?.title ?? "")
         }
     }
+    
+    private final func bindTextView(){
+        
+        let text = mainView.addExplainTextView.rx.text.orEmpty
+            .asObservable()
+            .startWith(CheckRegisterView.placeholder).share()
+        
+        text
+            .first()
+            .subscribe({ [weak self] _ in
+                self?.setTextColorEmptyMode()
+            }).disposed(by: disposeBag)
+        
+        mainView.addExplainTextView.rx.didBeginEditing
+            .withLatestFrom(text)
+            .bind(onNext: { [weak self] startText in
+                if(startText == CheckRegisterView.placeholder){
+                    self?.setTextEmpty()
+                }
+                self?.setTextColorEditingMode()
+            }).disposed(by: disposeBag)
+        
+        mainView.addExplainTextView.rx.didEndEditing
+            .withLatestFrom(text)
+            .bind(onNext: { [weak self] endText in
+                if(endText.isEmpty){
+                    self?.setTextPlaceholder()
+                    self?.setTextColorEmptyMode()
+                }
+            }).disposed(by: disposeBag)
+        
+        commentObservable = text
+            .filter{
+                $0 != CheckRegisterView.placeholder
+            }
+        
+    }
+    
+    private func setTextEmpty(){
+        mainView.addExplainTextView.text = nil
+    }
+    
+    private func setTextPlaceholder(){
+        mainView.addExplainTextView.text = CheckRegisterView.placeholder
+    }
+    
+    private func setTextColorEmptyMode(){
+        mainView.addExplainTextView.textColor = .black20
+    }
+    
+    private func setTextColorEditingMode(){
+        mainView.addExplainTextView.textColor = .black85
+    }
 
     //MARK: - Action
     
@@ -81,30 +134,6 @@ class CheckRegisterViewController: BaseViewController<LeftNavigationEtcButtonHea
         view.endEditing(true)
         UIView.animate(withDuration: 0.3){
             self.view.window?.frame.origin.y = 0
-        }
-    }
-    
-}
-
-//MARK: - TextView
-extension CheckRegisterViewController: UITextViewDelegate{
-    
-    func textViewDidBeginEditing(_ textView: UITextView) {
-
-        UIView.animate(withDuration: 0.3){
-            self.view.window?.frame.origin.y -= 200
-        }
-
-        if textView.text == CheckRegisterView.placeHolder {
-            textView.text = nil
-            textView.textColor = .black85
-        }
-    }
-
-    func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            textView.text = CheckRegisterView.placeHolder
-            textView.textColor = .black20
         }
     }
 }

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
@@ -9,9 +9,10 @@ import UIKit
 
 class CheckRegisterViewController: BaseViewController<LeftNavigationEtcButtonHeaderView, CheckRegisterView> {
     
-    //MARK: - LifeCycle
+    let myProductInfo: RegisterFirstInformationDTO
     
-    init(infoView: BaseView){
+    init(myProductInfo: RegisterFirstInformationDTO, infoView: MyProductInformationView){
+        self.myProductInfo = myProductInfo
         super.init(headerView: LeftNavigationEtcButtonHeaderView(title: "재치 등록하기", etcButton: Image.exit),
                    mainView: CheckRegisterView(infoView: infoView))
     }

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
@@ -61,12 +61,11 @@ class CheckRegisterViewController: BaseViewController<LeftNavigationEtcButtonHea
     }
     
     @objc func exitButtonDidClicked(){
-        self.navigationController?.popToRootViewController(animated: true)
+        navigationController?.popToRootViewController(animated: true)
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        self.view.endEditing(true)
-        
+        view.endEditing(true)
         UIView.animate(withDuration: 0.3){
             self.view.window?.frame.origin.y = 0
         }

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
@@ -37,7 +37,7 @@ class CheckRegisterViewController: BaseViewController<LeftNavigationEtcButtonHea
     //MARK: - Action
     
     @objc func registerBtnDidClicked(){
-        let alert = Alert.Register.generateAlert().show(in: self)
+        let alert = Alert.Register.show(in: self)
         alert.completion = {
             print("등록 완료 버튼 눌림")
         }

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import RxSwift
 
 class CheckRegisterViewController: BaseViewController<LeftNavigationEtcButtonHeaderView, CheckRegisterView> {
     
@@ -21,8 +22,10 @@ class CheckRegisterViewController: BaseViewController<LeftNavigationEtcButtonHea
         fatalError("init(coder:) has not been implemented")
     }
     
+    let registerSubject = PublishSubject<Void>()
+    var commentObservable: Observable<String>!
+    
     override func initialize(){
-        
         super.initialize()
         setDelegate()
         addButtonTarget()
@@ -66,7 +69,7 @@ class CheckRegisterViewController: BaseViewController<LeftNavigationEtcButtonHea
     @objc private func registerAlertWillShow(){
         let alert = Alert.Register.show(in: self)
         alert.completion = {
-            print("등록 완료 버튼 눌림")
+            self.registerSubject.onNext(Void())
         }
     }
     

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
@@ -24,16 +24,26 @@ class CheckRegisterViewController: BaseViewController<LeftNavigationEtcButtonHea
     override func initialize(){
         
         super.initialize()
-        
-        headerView.etcButton.addTarget(self, action: #selector(exitButtonDidClicked), for: .touchUpInside)
-        
-        mainView.photoCollectionView.initializeDelegate(self)
-        
-        mainView.addExplainTextView.delegate = self
-        
-        mainView.registerBtn.addTarget(self, action: #selector(registerBtnDidClicked), for: .touchUpInside)
-        
+        setDelegate()
+        addButtonTarget()
         bindingRegisterData()
+        bindTextView()
+    }
+    
+    private func setDelegate(){
+        mainView.photoCollectionView.initializeDelegate(self)
+    }
+    
+    private func addButtonTarget(){
+        headerView.etcButton.rx.tap
+            .subscribe(onNext: { [weak self] _ in
+                self?.exitButtonDidTap()
+            }).disposed(by: disposeBag)
+        
+        mainView.registerBtn.rx.tap
+            .subscribe(onNext: { [weak self] _ in
+                self?.registerAlertWillShow()
+            }).disposed(by: disposeBag)
     }
     
     private func bindingRegisterData(){
@@ -53,14 +63,14 @@ class CheckRegisterViewController: BaseViewController<LeftNavigationEtcButtonHea
 
     //MARK: - Action
     
-    @objc func registerBtnDidClicked(){
+    @objc private func registerAlertWillShow(){
         let alert = Alert.Register.show(in: self)
         alert.completion = {
             print("등록 완료 버튼 눌림")
         }
     }
     
-    @objc func exitButtonDidClicked(){
+    @objc private final func exitButtonDidTap(){
         navigationController?.popToRootViewController(animated: true)
     }
     

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/CheckRegisterViewController.swift
@@ -27,12 +27,28 @@ class CheckRegisterViewController: BaseViewController<LeftNavigationEtcButtonHea
         
         headerView.etcButton.addTarget(self, action: #selector(exitButtonDidClicked), for: .touchUpInside)
         
-        mainView.photoCollectionView.delegate = self
-        mainView.photoCollectionView.dataSource = self
+        mainView.photoCollectionView.initializeDelegate(self)
         
         mainView.addExplainTextView.delegate = self
         
         mainView.registerBtn.addTarget(self, action: #selector(registerBtnDidClicked), for: .touchUpInside)
+        
+        bindingRegisterData()
+    }
+    
+    private func bindingRegisterData(){
+        mainView.infoFrame.do{
+            $0.myProductCategoryTag
+                .setCategoryTitle(categoryId: myProductInfo.category)
+            $0.myProductNameLabel
+                .text = myProductInfo.productName
+        }
+        mainView.infoFrame.myProductDetailView.do{
+            $0.endDateFrame.setInfo(value: myProductInfo.endDate ?? "")
+            $0.buyDateFrame.setInfo(value: myProductInfo.buyDate ?? "")
+            $0.countFrame.setInfo(value: myProductInfo.count ?? "")
+            $0.openFrame.setInfo(value: Register.ProductOpenState(rawValue: myProductInfo.isOpen)?.title ?? "")
+        }
     }
 
     //MARK: - Action

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/CheckShareRegisterViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/CheckShareRegisterViewController.swift
@@ -20,4 +20,11 @@ class CheckShareRegisterViewController: CheckRegisterViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    override func bind() {
+        commentObservable
+            .subscribe(onNext: {
+                print("comment check",$0)
+            }).disposed(by: disposeBag)
+    }
 }

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/CheckShareRegisterViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/CheckShareRegisterViewController.swift
@@ -9,12 +9,15 @@ import UIKit
 
 class CheckShareRegisterViewController: CheckRegisterViewController {
     
-    init(){
-        super.init(infoView: CheckShareRegisterInfoView())
+    private let wantProductInfo: RegisterSecondInformationDTO
+    
+    init(myProductInfo: RegisterFirstInformationDTO, wantProductInfo: RegisterSecondInformationDTO){
+        self.wantProductInfo = wantProductInfo
+        super.init(myProductInfo: myProductInfo,
+                   infoView: CheckShareRegisterInfoView())
     }
     
     required init?(coder: NSCoder) {
-        super.init(infoView: CheckShareRegisterInfoView())
+        fatalError("init(coder:) has not been implemented")
     }
-    
 }

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/DeleteImageDetailViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/DeleteImageDetailViewController.swift
@@ -30,7 +30,7 @@ class DeleteImageDetailViewController: BaseViewController<EtcButtonHeaderView, I
     
     //MARK: - Action
     @objc func deleteButtonDidClicked(){
-        let alert = Alert.ImageDelete.generateAlert().show(in: self)
+        let alert = Alert.ImageDelete.show(in: self)
         alert.completion = {
             self.completion()
         }

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/ZatchRegisterFirstViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/ZatchRegisterFirstViewController.swift
@@ -104,7 +104,7 @@ class ZatchRegisterFirstViewController: BaseViewController<LeftNavigationHeaderV
             return
         }
         
-        _ = alert.generateAlert().show(in: self)
+        _ = alert.show(in: self)
     }
 
 }

--- a/Zatch/Presentation/ViewControllers/Register/Zatch/ZatchRegisterSecondViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Register/Zatch/ZatchRegisterSecondViewController.swift
@@ -106,13 +106,13 @@ class ZatchRegisterSecondViewController: BaseViewController<LeftNavigationEtcBut
     }
     
     @objc func shareBtnDidClicked(){
-        let vc = CheckShareRegisterViewController()
-        self.navigationController?.pushViewController(vc, animated: true)
+//        let vc = CheckShareRegisterViewController()
+//        self.navigationController?.pushViewController(vc, animated: true)
     }
     
     @objc func nextBtnDidClicked(){
-        let vc = CheckExchangeRegisterViewController()
-        self.navigationController?.pushViewController(vc, animated: true)
+//        let vc = CheckExchangeRegisterViewController()
+//        self.navigationController?.pushViewController(vc, animated: true)
     }
     
     @objc func exitBtnDidClicked(){

--- a/Zatch/Presentation/ViewControllers/Town/MapTownViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Town/MapTownViewController.swift
@@ -53,7 +53,7 @@ class MapTownViewController: KakaoMapViewController{
             
             self.present(alert, animated: false, completion: nil)
         }else{
-            _ = Alert.TownCertification.generateAlert().show(in: self)
+            _ = Alert.TownCertification.show(in: self)
         }
     }
     

--- a/Zatch/Presentation/ViewControllers/Town/TownRegisterMapViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Town/TownRegisterMapViewController.swift
@@ -47,6 +47,6 @@ class TownRegisterMapViewController: MapViewController, Map{
     }
     
     func showRegisterTownFailAlert(){
-        Alert.TownCertification.generateAlert().show(in: self)
+        Alert.TownCertification.show(in: self)
     }
 }

--- a/Zatch/Presentation/ViewModels/Register/RegisterFirstInfoTestViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Register/RegisterFirstInfoTestViewModel.swift
@@ -108,11 +108,8 @@ final class RegisterFirstInfoTestViewModel: BaseViewModel{
     
     private func dateFormat(_ date: Register.DateString?) -> String?{
         if let date = date{
-            return date.year + "." + date.month + "." + date.date
+            return date.year + "." + date.month.dateFormat + "." + date.date.dateFormat
         }
         return nil
     }
-}
-
-extension RegisterFirstInfoTestViewModel{
 }

--- a/Zatch/Presentation/Views/RegisterView/CheckExchangeRegisterInfoView.swift
+++ b/Zatch/Presentation/Views/RegisterView/CheckExchangeRegisterInfoView.swift
@@ -68,7 +68,7 @@ class CheckExchangeRegisterInfoView: BaseView, MyProductInformationView{
         
         myFrame.addSubview(myProductCategoryTag)
         myFrame.addSubview(myProductNameLabel)
-        myFrame.addSubview(myProductDetail)
+        myFrame.addSubview(myProductDetailView)
         
     }
     

--- a/Zatch/Presentation/Views/RegisterView/CheckExchangeRegisterInfoView.swift
+++ b/Zatch/Presentation/Views/RegisterView/CheckExchangeRegisterInfoView.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class CheckExchangeRegisterInfoView: BaseView{
+class CheckExchangeRegisterInfoView: BaseView, MyProductInformationView{
     
     let exchangeImage = UIImageView().then{
         $0.image = Image.exchange
@@ -50,7 +50,7 @@ class CheckExchangeRegisterInfoView: BaseView{
         $0.setTypoStyleWithMultiLine(typoStyle: .medium12)
         $0.textAlignment = .center
     }
-    let myProductDetail = CheckRegisterView.MyProductDetailView()
+    let myProductDetailView = CheckRegisterView.MyProductDetailView()
     
     
     override func hierarchy(){
@@ -115,7 +115,7 @@ class CheckExchangeRegisterInfoView: BaseView{
             $0.trailing.equalToSuperview().offset(-11)
             $0.height.equalTo(32)
         }
-        myProductDetail.snp.makeConstraints{
+        myProductDetailView.snp.makeConstraints{
             $0.top.equalTo(myProductNameLabel.snp.bottom).offset(11)
             $0.leading.equalToSuperview()
         }

--- a/Zatch/Presentation/Views/RegisterView/CheckRegisterView.swift
+++ b/Zatch/Presentation/Views/RegisterView/CheckRegisterView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class CheckRegisterView: BaseView {
     
-    init(infoView: BaseView){
+    init(infoView: MyProductInformationView){
         self.infoFrame = infoView
         super.init(frame: .zero)
     }
@@ -45,7 +45,7 @@ class CheckRegisterView: BaseView {
         $0.register(ImageRegisterCollectionViewCell.self, forCellWithReuseIdentifier: ImageRegisterCollectionViewCell.cellIdentifier)
     }
 
-    let infoFrame: BaseView
+    let infoFrame: MyProductInformationView
     
     let addTitle = UILabel().then{
         $0.text = "추가 설명"
@@ -129,6 +129,13 @@ class CheckRegisterView: BaseView {
         }
     }
 }
+
+protocol MyProductInformationView where Self: BaseView{
+    var myProductCategoryTag: ZatchComponent.FilledTag { get }
+    var myProductNameLabel: UILabel { get }
+    var myProductDetailView: CheckRegisterView.MyProductDetailView { get }
+}
+
 
 extension CheckRegisterView{
     

--- a/Zatch/Presentation/Views/RegisterView/CheckRegisterView.swift
+++ b/Zatch/Presentation/Views/RegisterView/CheckRegisterView.swift
@@ -182,7 +182,6 @@ extension CheckRegisterView.MyProductDetailView{
         private let infoLabel = UILabel().then{
             $0.setTypoStyleWithSingleLine(typoStyle: .medium12)
             $0.textColor = .black85
-            $0.text = "2022/02/03"
         }
         
         init(title: String){

--- a/Zatch/Presentation/Views/RegisterView/CheckRegisterView.swift
+++ b/Zatch/Presentation/Views/RegisterView/CheckRegisterView.swift
@@ -68,16 +68,16 @@ class CheckRegisterView: BaseView {
     }
     
     override func hierarchy(){
-        self.addSubview(titleView)
-        self.addSubview(registerBtn)
-        self.addSubview(photoFrame)
-        self.addSubview(infoFrame)
+        addSubview(titleView)
+        addSubview(registerBtn)
+        addSubview(photoFrame)
+        addSubview(infoFrame)
 
-        self.photoFrame.addSubview(photoTitle)
-        self.photoFrame.addSubview(photoCollectionView)
+        photoFrame.addSubview(photoTitle)
+        photoFrame.addSubview(photoCollectionView)
 
-        self.addSubview(addTitle)
-        self.addSubview(addExplainTextView)
+        addSubview(addTitle)
+        addSubview(addExplainTextView)
     }
 
     override func layout(){
@@ -150,16 +150,16 @@ extension CheckRegisterView{
         }
         
         private func hierarchy(){
-            self.addArrangedSubview(endDateFrame)
-            self.addArrangedSubview(buyDateFrame)
-            self.addArrangedSubview(countFrame)
-            self.addArrangedSubview(openFrame)
+            addArrangedSubview(endDateFrame)
+            addArrangedSubview(buyDateFrame)
+            addArrangedSubview(countFrame)
+            addArrangedSubview(openFrame)
         }
         
         private func style(){
-            self.axis = .vertical
-            self.spacing = 8
-            self.alignment = .leading
+            axis = .vertical
+            spacing = 8
+            alignment = .leading
         }
     }
 }
@@ -179,8 +179,8 @@ extension CheckRegisterView.MyProductDetailView{
         }
         
         init(title: String){
-            self.titleLabel.text = title
             super.init(frame: .zero)
+            titleLabel.text = title
             style()
             layout()
         }
@@ -190,14 +190,13 @@ extension CheckRegisterView.MyProductDetailView{
         }
         
         private func style(){
-            self.spacing = 10
-            self.axis = .horizontal
+            spacing = 10
+            axis = .horizontal
         }
         
         private func layout(){
-            self.addArrangedSubview(titleLabel)
-            self.addArrangedSubview(infoLabel)
-            
+            addArrangedSubview(titleLabel)
+            addArrangedSubview(infoLabel)
             titleLabel.snp.makeConstraints{
                 $0.width.equalTo(47)
             }

--- a/Zatch/Presentation/Views/RegisterView/CheckRegisterView.swift
+++ b/Zatch/Presentation/Views/RegisterView/CheckRegisterView.swift
@@ -20,7 +20,7 @@ class CheckRegisterView: BaseView {
     
     //MARK: - Properties
 
-    static let placeHolder = "추가 설명이 필요하다면 여기에 적어주세요."
+    static let placeholder = "추가 설명이 필요하다면 여기에 적어주세요."
 
     //MARK: - UI
     
@@ -56,7 +56,7 @@ class CheckRegisterView: BaseView {
         $0.layer.borderWidth = 1
         $0.layer.cornerRadius = 8
 
-        $0.text = CheckRegisterView.placeHolder
+        $0.text = CheckRegisterView.placeholder
         $0.setTextWithLineHeight(lineHeight: 15.6)
         $0.textColor = .black20
         $0.font = UIFont.pretendard(size: 12, family: .Medium)

--- a/Zatch/Presentation/Views/RegisterView/CheckShareRegisterInfoView.swift
+++ b/Zatch/Presentation/Views/RegisterView/CheckShareRegisterInfoView.swift
@@ -16,11 +16,9 @@ class CheckShareRegisterInfoView: BaseView, MyProductInformationView{
     let shareTag = ZatchComponent.Tag.filled(color: .yellow, configuration: .height20).then{
         $0.setTitle("나눔")
     }
-    let myProductCategoryTag = ZatchComponent.Tag.filled(color: .purple, configuration: .height20).then{
-        $0.setCategoryTitle(categoryId: 2)
-    }
+    let myProductCategoryTag = ZatchComponent.Tag.filled(color: .purple, configuration: .height20)
+
     let myProductNameLabel = UILabel().then{
-        $0.text = "맥도날드 해피밀 마이멜로디 장난감"
         $0.textColor = .black85
         $0.setTypoStyleWithSingleLine(typoStyle: .medium12)
     }

--- a/Zatch/Presentation/Views/RegisterView/CheckShareRegisterInfoView.swift
+++ b/Zatch/Presentation/Views/RegisterView/CheckShareRegisterInfoView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class CheckShareRegisterInfoView: BaseView{
+class CheckShareRegisterInfoView: BaseView, MyProductInformationView{
     
     let tagStackView = UIStackView().then{
         $0.axis = .horizontal
@@ -24,7 +24,8 @@ class CheckShareRegisterInfoView: BaseView{
         $0.textColor = .black85
         $0.setTypoStyleWithSingleLine(typoStyle: .medium12)
     }
-    let myProductDetail = CheckRegisterView.MyProductDetailView()
+    
+    let myProductDetailView = CheckRegisterView.MyProductDetailView()
     
     override func hierarchy() {
         self.addSubview(tagStackView)
@@ -44,7 +45,7 @@ class CheckShareRegisterInfoView: BaseView{
             $0.top.equalTo(tagStackView.snp.bottom).offset(7)
             $0.leading.equalToSuperview().offset(36)
         }
-        myProductDetail.snp.makeConstraints{
+        myProductDetailView.snp.makeConstraints{
             $0.top.equalTo(myProductNameLabel.snp.bottom).offset(22)
             $0.leading.equalToSuperview().offset(36)
         }

--- a/Zatch/Presentation/Views/RegisterView/CheckShareRegisterInfoView.swift
+++ b/Zatch/Presentation/Views/RegisterView/CheckShareRegisterInfoView.swift
@@ -26,9 +26,9 @@ class CheckShareRegisterInfoView: BaseView, MyProductInformationView{
     let myProductDetailView = CheckRegisterView.MyProductDetailView()
     
     override func hierarchy() {
-        self.addSubview(tagStackView)
-        self.addSubview(myProductNameLabel)
-        self.addSubview(myProductDetail)
+        addSubview(tagStackView)
+        addSubview(myProductNameLabel)
+        addSubview(myProductDetailView)
         
         tagStackView.addArrangedSubview(shareTag)
         tagStackView.addArrangedSubview(myProductCategoryTag)


### PR DESCRIPTION
## What is this PR? 🔍
재치 등록 점검 RxSwift 활용 리팩토링 및 나눔/교환 공통 데이터 UI 바인딩 구현

## Key Changes 🔑
### 1. Alert show 메서드 추상화
+ 기존 코드
``` swift
Alert.ChattingRoomExit.generateAlert().show(in: self)
```
+ NEW ver.
``` swift
Alert.ChattingRoomExit.show(in: self)
```
+ 생성 과정은 굳이 알 필요 없다고 판단하여 추상화 진행했습니다. 

### 2. MyProductInformationView 프로토콜 선언
+ 재치 점검 프로세스에서 나눔/교환 상관없이 내 상품 정보는 공통으로 바인딩 진행해야 합니다. 
+ 재치 관련 정보는 기존 BaseView 타입으로 해 각각의 클래스에서 맞는 InfoView 인스턴스를 넘겨주는 방식이었습니다. 
+ 공통 정보는 상위 클래스에 바인딩 하는 것이 맞다고 판단했습니다. 
+ MyProductInformationView 프로토콜에 공통 정보 관련 프로퍼티를 선언했으며, CheckExchangeRegisterInfoView와 CheckShareRegisterInfoView가 각각 채택하도록 하였습니다. 
+ 따라서 CheckRegisterViewController에서 아래 3가지 데이터를 UI에 바인딩시켰습니다. 

  1. 내 상품 카테고리
  2. 내 상품 이름
  3. 내 상품 세부 정보


### 3. RegisterFirstInfoTestViewModel 날짜 형태 오류 수정
+ yyyy.M.d 형태로 값이 넘어가고 있었습니다. 
+ String.dateFormat extension 프로퍼티를 통해 10이하인 경우 앞에 0을 추가하는 기능을 추가하였습니다. 

### 4. 재치 등록 점검 코멘트 TextView RxSwift 활용해 기능 구현
+ 기존 UITextViewDelegate 메서드 활용해 기능 구현했었습니다. 
+ delegate 위임 제거하고, RxSwift 활용해 기능 제공하는 것으로 리팩토링 완료했습니다. 
+ 아직 TextView가 사용됐던 곳이 여기 말고는 딱히 없는 것으로 기억해서 기능을 모듈화시키진 않았는데, 혹시 다른곳에서도 사용되는 곳이 있다면 모듈화 시켜 재사용하도록 하겠습니다. 

## Related Issues ⛱
#218, #222
