### PR TITLE
Network/#242-#243: 인기있는 검색 키워드 API 연결 및 내가 원하는 재치 ViewModel 설계 변경

### DIFF
--- a/Zatch.xcodeproj/project.pbxproj
+++ b/Zatch.xcodeproj/project.pbxproj
@@ -284,6 +284,9 @@
 		EE41019329854DED0083B7E0 /* LeftNavigationTitleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41019229854DED0083B7E0 /* LeftNavigationTitleHeaderView.swift */; };
 		EE41019529854EE60083B7E0 /* LeftNavigationEtcButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41019429854EE60083B7E0 /* LeftNavigationEtcButtonHeaderView.swift */; };
 		EE410197298557440083B7E0 /* ImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE410196298557440083B7E0 /* ImageDetailView.swift */; };
+		EE42D5BF2A1B33FC001BEF64 /* PopularKeywordResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE42D5BE2A1B33FC001BEF64 /* PopularKeywordResponseModel.swift */; };
+		EE42D5C22A1B3575001BEF64 /* SearchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE42D5C12A1B3575001BEF64 /* SearchRouter.swift */; };
+		EE42D5C42A1B357C001BEF64 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE42D5C32A1B357C001BEF64 /* SearchService.swift */; };
 		EE4CE7B929F910AF00943FE5 /* FAQ.json in Resources */ = {isa = PBXBuildFile; fileRef = EE4CE7B829F910AF00943FE5 /* FAQ.json */; };
 		EE4CE7C729FCF60E00943FE5 /* LoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4CE7C629FCF60E00943FE5 /* LoginUseCase.swift */; };
 		EE4CE7CA29FCF6FD00943FE5 /* LoginResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4CE7C929FCF6FD00943FE5 /* LoginResponseModel.swift */; };
@@ -711,6 +714,9 @@
 		EE41019229854DED0083B7E0 /* LeftNavigationTitleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftNavigationTitleHeaderView.swift; sourceTree = "<group>"; };
 		EE41019429854EE60083B7E0 /* LeftNavigationEtcButtonHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftNavigationEtcButtonHeaderView.swift; sourceTree = "<group>"; };
 		EE410196298557440083B7E0 /* ImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailView.swift; sourceTree = "<group>"; };
+		EE42D5BE2A1B33FC001BEF64 /* PopularKeywordResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularKeywordResponseModel.swift; sourceTree = "<group>"; };
+		EE42D5C12A1B3575001BEF64 /* SearchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRouter.swift; sourceTree = "<group>"; };
+		EE42D5C32A1B357C001BEF64 /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
 		EE4CE7B829F910AF00943FE5 /* FAQ.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FAQ.json; sourceTree = "<group>"; };
 		EE4CE7C629FCF60E00943FE5 /* LoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCase.swift; sourceTree = "<group>"; };
 		EE4CE7C929FCF6FD00943FE5 /* LoginResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponseModel.swift; sourceTree = "<group>"; };
@@ -1045,6 +1051,7 @@
 				57B32C2F291F55F20018C0CB /* Zatch */,
 				57A28D5428D1A07000263079 /* Map */,
 				57D6D7A128CDC30C00F805B7 /* ChattingModels */,
+				EE42D5BD2A1B33DF001BEF64 /* Search */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2010,6 +2017,23 @@
 			path = MyZatch;
 			sourceTree = "<group>";
 		};
+		EE42D5BD2A1B33DF001BEF64 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				EE42D5BE2A1B33FC001BEF64 /* PopularKeywordResponseModel.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		EE42D5C02A1B356D001BEF64 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				EE42D5C12A1B3575001BEF64 /* SearchRouter.swift */,
+				EE42D5C32A1B357C001BEF64 /* SearchService.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
 		EE4CE7B729F9105000943FE5 /* FAQ */ = {
 			isa = PBXGroup;
 			children = (
@@ -2096,6 +2120,7 @@
 		EE4D887D29CFFA69003B6383 /* MoyaService */ = {
 			isa = PBXGroup;
 			children = (
+				EE42D5C02A1B356D001BEF64 /* Search */,
 				EE4CE7D829FD028E00943FE5 /* User */,
 				EE4D887729CFF399003B6383 /* Zatch */,
 				EE4D887829CFF3AA003B6383 /* Map */,
@@ -2791,6 +2816,7 @@
 				EEC3753429F8E22300190B22 /* ModifyProfileViewModel.swift in Sources */,
 				5722462928C77D64009B7C78 /* SearchAddressResultBottomSheet.swift in Sources */,
 				235613FD28D09DCD00D44E97 /* ZatchTableViewCell.swift in Sources */,
+				EE42D5C22A1B3575001BEF64 /* SearchRouter.swift in Sources */,
 				23B051CA28E21BAD005D08EA /* MyQuestionTableViewCell.swift in Sources */,
 				57A28D5628D1A0BB00263079 /* GetTownResponseModel.swift in Sources */,
 				57713944281F596C0066DEEB /* TopTitleView.swift in Sources */,
@@ -2891,6 +2917,7 @@
 				576341A728D29CC70067D2C5 /* BlockUserViewController.swift in Sources */,
 				EE1840CE2A0C9FAB00DF5D06 /* ZatchLikeResponseModel.swift in Sources */,
 				EE7AFF5729D16652007872B9 /* MeetingLocationRegisterMapViewController.swift in Sources */,
+				EE42D5C42A1B357C001BEF64 /* SearchService.swift in Sources */,
 				574EC1ED282E62A000E3CE4B /* RegisterCategorySelectTableViewCell.swift in Sources */,
 				57FFEDC528DD2F0D0041719B /* CheckShareRegisterViewController.swift in Sources */,
 				EE0AD54729E5033400C1CDA1 /* RegisterFirstInfoViewController.swift in Sources */,
@@ -2978,6 +3005,7 @@
 				571C0C7728AB5070002293B6 /* HiddenDeleteView.swift in Sources */,
 				23B7FBB028CECEAF0018642E /* MyZatchStatisticTableViewCell.swift in Sources */,
 				232DD0AD28ECE00900BC6E91 /* OtherReviewTableViewCell.swift in Sources */,
+				EE42D5BF2A1B33FC001BEF64 /* PopularKeywordResponseModel.swift in Sources */,
 				57D6D78D28CDB59100F805B7 /* MessageAlertViewController.swift in Sources */,
 				5722461028C074AE009B7C78 /* TimePickerAlertViewController.swift in Sources */,
 				57468A74289D071100056691 /* UIButton.swift in Sources */,

--- a/Zatch/AppDelegate/SceneDelegate.swift
+++ b/Zatch/AppDelegate/SceneDelegate.swift
@@ -27,7 +27,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 //        var startViewController: UIViewController
 //        startViewController = UserManager.token == nil ? UINavigationController(rootViewController: OnboardingViewController()) : TabBarController()
         
-        window?.rootViewController = UINavigationController(rootViewController: ZatchDetailViewController.getInstance(data: TemporaryData.zatch))
+        window?.rootViewController = UINavigationController(rootViewController: FindWantZatchSearchViewController())
 //        window?.rootViewController = TabBarController()
         window?.makeKeyAndVisible()
     }

--- a/Zatch/Data/Foundation/HTTPMethodURL.swift
+++ b/Zatch/Data/Foundation/HTTPMethodURL.swift
@@ -10,6 +10,7 @@ import Foundation
 enum HTTPMethodURL {
 
     static let zatchUrl = "/zatch"
+    static let searchUrl = "/search"
     static let userUrl = "/users"
     static let kakaoLocal = "/v2/local"
     
@@ -21,6 +22,9 @@ enum HTTPMethodURL {
         
         //USER
         static let logout = userUrl + "/logout"
+        
+        //SEARCH
+        static let popularKeywords = zatchUrl + searchUrl + "/popularItem"
     }
     
     struct POST {

--- a/Zatch/Data/Models/Search/PopularKeywordResponseModel.swift
+++ b/Zatch/Data/Models/Search/PopularKeywordResponseModel.swift
@@ -1,0 +1,23 @@
+//
+//  PopularKeywordResponseModel.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/05/22.
+//
+
+import Foundation
+
+struct PopularKeywordsResponseModel: Decodable{
+    let popularItem: [PopularKeywords]
+}
+
+struct PopularKeywords: Decodable{
+    
+    let keyword: String
+    let likeCount: Int
+    
+    enum CodingKeys: String, CodingKey{
+        case keyword = "md_name"
+        case likeCount = "like_count"
+    }
+}

--- a/Zatch/Data/MoyaService/Search/SearchRouter.swift
+++ b/Zatch/Data/MoyaService/Search/SearchRouter.swift
@@ -1,0 +1,36 @@
+//
+//  SearchRouter.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/05/22.
+//
+
+import Foundation
+import Moya
+
+enum SearchRouter: BaseRouter{
+    case getPopularKeywords
+}
+
+extension SearchRouter{
+    
+    var path: String {
+        switch self {
+        case .getPopularKeywords:       return HTTPMethodURL.GET.popularKeywords
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getPopularKeywords:       return .get
+        }
+    }
+    
+    var task: Task {
+        switch self{
+        case .getPopularKeywords:       return .requestPlain
+        }
+    }
+}
+
+

--- a/Zatch/Data/MoyaService/Search/SearchService.swift
+++ b/Zatch/Data/MoyaService/Search/SearchService.swift
@@ -1,0 +1,22 @@
+//
+//  SearchService.swift
+//  Zatch
+//
+//  Created by 박소윤 on 2023/05/22.
+//
+
+import Foundation
+
+public class SearchService {
+    
+    static let shared = SearchService()
+    let provider = BaseService(plugins: [MoyaLoggerPlugin()])
+    
+    private init() { }
+    
+    func getPopularKeywords(completion: @escaping (Result<PopularKeywordsResponseModel, Error>) -> Void){
+        provider.requestDecoded(SearchRouter.getPopularKeywords){ response in
+            completion(response)
+        }
+    }
+}

--- a/Zatch/Data/Repository/SearchRepository.swift
+++ b/Zatch/Data/Repository/SearchRepository.swift
@@ -6,12 +6,26 @@
 //
 
 import Foundation
+import RxSwift
 
 class SearchRepository: SearchRepositotyInterface{
+
     func getSearchResult() {
         
     }
-    
-    func getPopularKeyword() {
+
+    func getPopularKeywords() -> Observable<[PopularKeywords]?> {
+        let observable = Observable<[PopularKeywords]?>.create { observer -> Disposable in
+            let requestReference: () = SearchService.shared.getPopularKeywords{ response in
+                switch response {
+                case .success(let data):
+                    observer.onNext(data.popularItem)
+                case .failure:
+                    observer.onNext(nil)
+                }
+            }
+            return Disposables.create(with: { requestReference })
+        }
+        return observable
     }
 }

--- a/Zatch/Domain/RepositoryInterface/SearchRepositotyInterface.swift
+++ b/Zatch/Domain/RepositoryInterface/SearchRepositotyInterface.swift
@@ -6,8 +6,9 @@
 //
 
 import Foundation
+import RxSwift
 
 protocol SearchRepositotyInterface{
-    func getPopularKeyword()
+    func getPopularKeywords() -> Observable<[PopularKeywords]?>
     func getSearchResult()
 }

--- a/Zatch/Domain/UseCase/Search/PopularKeywordUseCase.swift
+++ b/Zatch/Domain/UseCase/Search/PopularKeywordUseCase.swift
@@ -6,12 +6,10 @@
 //
 
 import Foundation
-
-struct PopularKeywordRequestValue {
-}
+import RxSwift
 
 protocol PopularKeywordUseCaseInterface {
-    func execute(requestValue: PopularKeywordRequestValue) async throws
+    func execute() -> Observable<[PopularKeywords]?>
 }
 
 final class PopularKeywordUseCase: PopularKeywordUseCaseInterface {
@@ -22,7 +20,7 @@ final class PopularKeywordUseCase: PopularKeywordUseCaseInterface {
         self.searchRepository = searchRepository
     }
 
-    func execute(requestValue: PopularKeywordRequestValue) async throws {
-        return try await searchRepository.getPopularKeyword()
+    func execute() -> Observable<[PopularKeywords]?>{
+        return searchRepository.getPopularKeywords()
     }
 }

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/FindWantZatchSearchViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/FindWantZatchSearchViewController.swift
@@ -12,6 +12,12 @@ import RxSwift
 
 class FindWantZatchSearchViewController: BaseViewController<BaseHeaderView, FindWantZatchSearchView> {
     
+    @frozen
+    enum SearchKeywordType: Int{
+        case popular = 100
+        case want = 200
+    }
+    
     //MARK: - Properties
     private var currentSelectCell: SearchTagCollectionViewCell?{
         willSet{

--- a/Zatch/Presentation/ViewControllers/Search/Zatch/FindWantZatchSearchViewController.swift
+++ b/Zatch/Presentation/ViewControllers/Search/Zatch/FindWantZatchSearchViewController.swift
@@ -44,13 +44,24 @@ class FindWantZatchSearchViewController: BaseViewController<BaseHeaderView, Find
     }
     
     override func initialize() {
-        
         super.initialize()
-        
+        addBtnTarget()
+        setCollectionViewDelegate()
+        attachCollectionViewTag()
+    }
+    
+    private func addBtnTarget(){
         mainView.nextButton.addTarget(self, action: #selector(willMoveSearchResultViewController), for: .touchUpInside)
-        
+    }
+    
+    private func setCollectionViewDelegate(){
         mainView.popularKeywordCollectionView.initializeDelegate(self)
         mainView.lookingForCollectionView.initializeDelegate(self)
+    }
+    
+    private func attachCollectionViewTag(){
+        mainView.popularKeywordCollectionView.tag = SearchKeywordType.popular.rawValue
+        mainView.lookingForCollectionView.tag = SearchKeywordType.want.rawValue
     }
     
     override func bind() {

--- a/Zatch/Presentation/ViewModels/Search/FindWantZatchSearchViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Search/FindWantZatchSearchViewModel.swift
@@ -27,15 +27,14 @@ protocol FindWantZatchViewModelInterface: BaseViewModel, GetPopularSearchKeyword
     func viewDidLoad()
 }
 
-class FindWantZatchSearchViewModel: BaseViewModel{
+class FindWantZatchSearchViewModel: FindWantZatchViewModelInterface{
+
+    var popularKeywords = [PopularKeywords]()
+    var lookingForZatches = ["몰랑이", "몰랑", "몰랑몰랑"]//[String]()
     
-    private var searchPopularKeywords = ["몰랑이","몰랑몰랑","몰랑"] //최대 3개
-    private var lookingForZatches = ["몰랑이","몰랑몰랑","몰랑"] //최대 3개
-    
-    private let searchManager = ZatchSearchRequestManager.shared
-    
-    private let wantProductName = PublishSubject<String>()
-    private let disposeBag = DisposeBag()
+    let productName = PublishRelay<String>()
+    let reloadPopularData = PublishSubject<Void>()
+    let reloadLookingForData = PublishSubject<Void>()
     
     private let popularKeywordUseCase: PopularKeywordUseCaseInterface
     private let lookingForZatchUseCase: LookingForZatchUseCaseInterface
@@ -45,6 +44,9 @@ class FindWantZatchSearchViewModel: BaseViewModel{
         self.popularKeywordUseCase = popularKeywordUseCase
         self.lookingForZatchUseCase = lookingForZatchUseCase
     }
+    
+    private let disposeBag = DisposeBag()
+    private let searchManager = ZatchSearchRequestManager.shared
     
     struct Input{
         let productNameTextField: Observable<String>
@@ -58,15 +60,15 @@ class FindWantZatchSearchViewModel: BaseViewModel{
         
         input.productNameTextField
             .subscribe{
-                self.wantProductName.onNext($0)
+                self.productName.accept($0)
             }.disposed(by: disposeBag)
         
-        wantProductName
+        productName
             .subscribe(onNext: {
                 self.searchManager.wantProduct = $0
             }).disposed(by: disposeBag)
         
-        let productName = wantProductName
+        let productName = productName
             .asDriver(onErrorJustReturn: "")
         
         return Output(searchProduct: productName)
@@ -76,31 +78,17 @@ class FindWantZatchSearchViewModel: BaseViewModel{
 
 extension FindWantZatchSearchViewModel{
     
-    func getPopularKeywordsCount() -> Int{
-        searchPopularKeywords.count
-    }
-    
-    func getLookingForZatchCount() -> Int{
-        lookingForZatches.count
-    }
-    
-    func getPopularKeyword(at: Int) -> String{
-        searchPopularKeywords[at]
-    }
-    
-    func getLookingForZatch(at: Int) -> String{
-        lookingForZatches[at]
-    }
-    
-    func selectPopularKeyword(at index: Int){
-        wantProductName.onNext(searchPopularKeywords[index])
-    }
-    
-    func selectLookingForZatch(at index: Int){
-        wantProductName.onNext(lookingForZatches[index])
-    }
-    
-    func deselectCell(){
-        wantProductName.onNext("")
+    func viewDidLoad(){
+        //인기있는 재치 키워드 조회
+        popularKeywordUseCase.execute()
+            .subscribe{ [weak self] in
+                if let data = $0 {
+                    self?.popularKeywords = data
+                    self?.reloadPopularData.onNext(Void())
+                }
+            }.disposed(by: disposeBag)
+        
+        //내가 찾는 재치 키워드 조회
+        reloadLookingForData.onNext(Void())
     }
 }

--- a/Zatch/Presentation/ViewModels/Search/FindWantZatchSearchViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Search/FindWantZatchSearchViewModel.swift
@@ -10,14 +10,20 @@ import RxSwift
 import RxCocoa
 
 protocol GetPopularSearchKeywordInterface{
-    var popularKeywords: [String] { get }
+    var reloadPopularData: PublishSubject<Void> { get }
+    var popularKeywords: [PopularKeywords] { get }
 }
 
 protocol GetWantZatchKeywordInterface{
+    var reloadLookingForData: PublishSubject<Void> { get }
     var lookingForZatches : [String] { get }
 }
 
-protocol FindWantZatchViewModelInterface: BaseViewModel, GetPopularSearchKeywordInterface, GetWantZatchKeywordInterface {
+protocol SearchProductInterface{
+    var productName: PublishRelay<String> { get }
+}
+
+protocol FindWantZatchViewModelInterface: BaseViewModel, GetPopularSearchKeywordInterface, GetWantZatchKeywordInterface, SearchProductInterface {
     func viewDidLoad()
 }
 

--- a/Zatch/Presentation/ViewModels/Search/FindWantZatchSearchViewModel.swift
+++ b/Zatch/Presentation/ViewModels/Search/FindWantZatchSearchViewModel.swift
@@ -9,6 +9,18 @@ import Foundation
 import RxSwift
 import RxCocoa
 
+protocol GetPopularSearchKeywordInterface{
+    var popularKeywords: [String] { get }
+}
+
+protocol GetWantZatchKeywordInterface{
+    var lookingForZatches : [String] { get }
+}
+
+protocol FindWantZatchViewModelInterface: BaseViewModel, GetPopularSearchKeywordInterface, GetWantZatchKeywordInterface {
+    func viewDidLoad()
+}
+
 class FindWantZatchSearchViewModel: BaseViewModel{
     
     private var searchPopularKeywords = ["몰랑이","몰랑몰랑","몰랑"] //최대 3개


### PR DESCRIPTION
## What is this PR? 🔍
인기있는 검색 키워드 API 연결 및 내가 원하는 재치 ViewModel 설계 변경

## Key Changes 🔑
### 1. 인기있는 검색 키워드 API 연결

### 2. 내가 원하는 재치 ViewModel 설계 변경
+ 책임 기반으로 설계 변경했습니다. 
+ 의존성 제거를 위해 프로토콜을 활용하였습니다. 
+ 각 책임마다 분리하여 프로토콜 설계 및 구현하였습니다. 

### 💭 고민한 부분
원하는 재치 물품에 대해서 
1. TextField로 입력
2. Tag 셀을 눌러 키워드를 입력

2가지 방식으로 인해 데이터 변수 선언을 어떻게 해야하나 고민했습니다. 

결론적으로 ViewModel에 internal 접근 제어와 Subject 타입으로 선언 -> Cell을 통해 데이터를 입력받을 때 ViewModel 프로퍼티에 접근해 새로운 데이터를 방출하는 것으로 결정하였습니다. 
VC이 ViewModel의 프로퍼티를 알고 직접 데이터를 넣어도 되나?를 고민했는데, 헷갈렸던 부분이라 MVVM 패턴을 다시 공부하였습니다. 
VC이 ViewModel을 소유하는 것이기에, VC은 ViewModel의 정보를 알고 있어도 된다고 판단했습니다.
따라서 internal을 통해 ViewModel의 프로퍼티에 데이터를 새로 방출해도 괜찮다고 판단하여 설계 및 리팩토링 진행하였습니다. 

## Related Issues ⛱
#242 #243
